### PR TITLE
[SPIRV] Have SPIRV IDs start at 1

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -54,7 +54,7 @@ typedef uint32_t SPIRVId;
 #define SPIRVWORD_MAX     ~0U
 
 inline bool
-isValid(SPIRVId Id) { return Id != SPIRVID_INVALID;}
+isValid(SPIRVId Id) { return Id != SPIRVID_INVALID && Id != 0;}
 
 inline SPIRVWord
 mkWord(unsigned WordCount, Op OpCode) {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -61,7 +61,7 @@ SPIRVModule::~SPIRVModule()
 
 class SPIRVModuleImpl : public SPIRVModule {
 public:
-  SPIRVModuleImpl():SPIRVModule(), NextId(0), BoolType(NULL),
+  SPIRVModuleImpl():SPIRVModule(), NextId(1), BoolType(NULL),
     SPIRVVersion(SPV_VERSION),
     GeneratorId(SPIRVGEN_KhronosLLVMSPIRVTranslator),
     GeneratorVer(0),


### PR DESCRIPTION
The SPIR-V specification states that an ID `id` is valid if
`0 < id < max_bound`. Therefore, an id of 0 is invalid and will be now
correctly reported by `isValid(SPIRVId)`.

Fixes: KhronosGroup/SPIRV-LLVM#1
