### PR TITLE
Add support for OpDecorate LinkageAttributes name

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -120,6 +120,28 @@ public:
   void setWordCount(SPIRVWord);
 };
 
+class SPIRVDecorateLinkageAttr:public SPIRVDecorate{
+public:
+  // Complete constructor for LinkageAttributes decorations
+  SPIRVDecorateLinkageAttr(SPIRVEntry *TheTarget,
+      const std::string &Name, SPIRVLinkageTypeKind Kind)
+    :SPIRVDecorate(DecorationLinkageAttributes, TheTarget) {
+      WordCount += getSizeInWords(Name) + 1u;
+      for (auto &I:getVec(Name))
+        Literals.push_back(I);
+      Literals.push_back(Kind);
+    }
+  // Incomplete constructor
+  SPIRVDecorateLinkageAttr():SPIRVDecorate(){}
+
+  std::string getLinkageName() const {
+    return getString(Literals.cbegin(), Literals.cend() - 1);
+  }
+  SPIRVLinkageTypeKind getLinkageType() const {
+    return (SPIRVLinkageTypeKind)Literals.back();
+  }
+};
+
 class SPIRVMemberDecorate:public SPIRVDecorateGeneric{
 public:
   static const Op OC = OpMemberDecorate;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -375,17 +375,17 @@ SPIRVEntry::encodeDecorate(std::ostream &O) const {
 SPIRVLinkageTypeKind
 SPIRVEntry::getLinkageType() const {
   assert(hasLinkageType());
-  SPIRVWord LT = LinkageTypeInternal;
-  if (!hasDecorate(DecorationLinkageAttributes, 0, &LT))
+  DecorateMapType::const_iterator Loc = Decorates.find(DecorationLinkageAttributes);
+  if (Loc == Decorates.end())
     return LinkageTypeInternal;
-  return static_cast<SPIRVLinkageTypeKind>(LT);
+  return static_cast<const SPIRVDecorateLinkageAttr*>(Loc->second)->getLinkageType();
 }
 
 void
 SPIRVEntry::setLinkageType(SPIRVLinkageTypeKind LT) {
   assert(isValid(LT));
   assert(hasLinkageType());
-  addDecorate(new SPIRVDecorate(DecorationLinkageAttributes, this, LT));
+  addDecorate(new SPIRVDecorateLinkageAttr(this, Name, LT));
 }
 
 std::ostream &

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -310,6 +310,44 @@ getSizeInWords(const std::string& Str) {
   return static_cast<unsigned>(Str.length()/4 + 1);
 }
 
+inline std::string
+getString(std::vector<uint32_t>::const_iterator Begin,
+    std::vector<uint32_t>::const_iterator End) {
+  std::string Str = std::string();
+  for (auto I = Begin; I != End; ++I) {
+    uint32_t Word = *I;
+    for (unsigned J = 0u; J < 32u; J += 8u) {
+      char Char = (char)((Word >> J) & 0xff);
+      if (Char == '\0')
+        return Str;
+      Str += Char;
+    }
+  }
+  return Str;
+}
+
+inline std::string
+getString(const std::vector<uint32_t> &V) {
+  return getString(V.cbegin(), V.cend());
+}
+
+inline std::vector<uint32_t>
+getVec(const std::string &Str) {
+  std::vector<uint32_t> V;
+  auto StrSize = Str.size();
+  uint32_t CurrentWord = 0u;
+  for (unsigned I = 0u; I < StrSize; ++I) {
+    if (I % 4u == 0u && I != 0u) {
+      V.push_back(CurrentWord);
+      CurrentWord = 0u;
+    }
+    CurrentWord += ((uint32_t)Str[I]) << ((I % 4u) * 8u);
+  }
+  if (CurrentWord != 0u)
+    V.push_back(CurrentWord);
+  return V;
+}
+
 template<typename T>
 inline std::vector<T>
 getVec(T Op1) {


### PR DESCRIPTION
This still needs some work, but at least it works for my use case (see #3) and I'll be able to get some feedback on the patch.

I'm thinking for the v2 to add a patch changing the `SPIRVDecorate` constructor to take multiple words, in order to support all decorations taking a literal number, as that number might span on multiple words. This new constructor could then be used by the `OpDecorateLinkageAttr` for passing the name and type of the linkage, and avoid doing `WordCount += getSizeInWords(Name) + 1u;`.
I should also run `clang-format` for the v2, but I have to check how it works first, since I never used it.
