### PR TITLE
Fix SPV_VERSION definition

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -61,7 +61,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 4;
+  const static unsigned short kTranslatorVer = 5;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -46,7 +46,7 @@ namespace spv {
 
 typedef unsigned int Id;
 
-#define SPV_VERSION 10000
+#define SPV_VERSION 0x10000
 #define SPV_REVISION 2
 
 static const unsigned int MagicNumber = 0x07230203;


### PR DESCRIPTION
The specification defines the version number as

> 0 | Major Number | Minor Number | 0

which results in version `1.00` being defined as `0x00010000`. The previous
value was set to `10000`, resulting in `0x00002710`.

See: KhronosGroup/SPIRV-Tools#15
