### PR TITLE
Fix instructions order when writing the binary module

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -61,7 +61,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 4;
+  const static unsigned short kTranslatorVer = 5;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1072,17 +1072,18 @@ operator<< (std::ostream &O, SPIRVModule &M) {
           << MI.NextId /* Bound for Id */
           << MI.InstSchema;
   O << SPIRVNL;
-  O << SPIRVSource(&M);
-  for (auto &I:M.getSourceExtension()) {
-    assert(!I.empty() && "Invalid source extension");
-    O << SPIRVSourceExtension(&M, I);
-  }
+
+  for (auto &I:MI.CapSet)
+    O << SPIRVCapability(&M, I);
+
   for (auto &I:M.getExtension()) {
     assert(!I.empty() && "Invalid extension");
     O << SPIRVExtension(&M, I);
   }
-  for (auto &I:MI.CapSet)
-    O << SPIRVCapability(&M, I);
+  for (auto &I:MI.IdBuiltinMap)
+    O <<  SPIRVExtInstImport(&M, I.first, SPIRVBuiltinSetNameMap::map(I.second));
+
+  O << SPIRVMemoryModel(&M);
 
   for (auto &I:MI.EntryPointVec)
     for (auto &II:I.second)
@@ -1093,12 +1094,12 @@ operator<< (std::ostream &O, SPIRVModule &M) {
     for (auto &II:I.second)
       MI.get<SPIRVFunction>(II)->encodeExecutionModes(O);
 
-  for (auto &I:MI.IdBuiltinMap)
-    O <<  SPIRVExtInstImport(&M, I.first, SPIRVBuiltinSetNameMap::map(I.second));
-
-  O << SPIRVMemoryModel(&M);
-
   O << MI.StringVec;
+  O << SPIRVSource(&M);
+  for (auto &I:M.getSourceExtension()) {
+    assert(!I.empty() && "Invalid source extension");
+    O << SPIRVSourceExtension(&M, I);
+  }
 
   for (auto &I:MI.NamedId) {
     // Don't output name for entry point since it is redundant


### PR DESCRIPTION
`OpSource` and `OpSourceExtension` have been moved to the debug group,
`OpCapability` instructions should be placed at the top and `OpExtInstImport`
and `OpMemoryModel` should be placed between `OpExtension` and `OpEntryPoint`.

Extract of the "Logical Layout of a Module" from the SPIR-V specification:

> 1. All `OpCapability` instructions.
> 2. Optional `OpExtension` instructions (extensions to SPIR-V).
> 3. Optional `OpExtInstImport` instructions.
> 4. The single required `OpMemoryModel` instruction.
> 5. All entry point declarations, using `OpEntryPoint`.
> 6. All execution mode declarations, using `OpExecutionMode`.
> 7. These debug instructions, which must be in the following order:
>    1. all `OpString`, `OpSourceExtension`, `OpSource`, and `OpSourceContinued`, without forward references.
>    2. all `OpName` and all `OpMemberName`
