### PR TITLE
[SPIRV] github issue#5 Capabilities required by OpDecorate are not ad…

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1027,7 +1027,7 @@ OCL20ToSPIRV::visitCallVecLoadStore(CallInst* CI,
   if (DemangledName.find(kOCLBuiltinName::VLoadPrefix) == 0 &&
       DemangledName != kOCLBuiltinName::VLoadHalf) {
     SPIRVWord Width = getVecLoadWidth(DemangledName);
-    SPIRVDBG(bildbgs() << "[visitCallVecLoadStore] DemangledName: " <<
+    SPIRVDBG(spvdbgs() << "[visitCallVecLoadStore] DemangledName: " <<
         DemangledName << " Width: " << Width << '\n');
     PreOps.push_back(Width);
   } else if (DemangledName.find(kOCLBuiltinName::RoundingPrefix)

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -404,24 +404,9 @@ SPIRVMap<OclExt::Kind, SPIRVCapabilityKind>::init() {
   add(OclExt::cl_khr_int64_base_atomics, CapabilityInt64Atomics);
   add(OclExt::cl_khr_int64_extended_atomics, CapabilityInt64Atomics);
   add(OclExt::cl_khr_fp16, CapabilityFloat16);
-  add(OclExt::cl_khr_gl_sharing, CapabilityNone);
-  add(OclExt::cl_khr_gl_event, CapabilityNone);
-  add(OclExt::cl_khr_d3d10_sharing, CapabilityNone);
-  add(OclExt::cl_khr_media_sharing, CapabilityNone);
-  add(OclExt::cl_khr_d3d11_sharing, CapabilityNone);
-  add(OclExt::cl_khr_global_int32_base_atomics, CapabilityNone);
-  add(OclExt::cl_khr_global_int32_extended_atomics, CapabilityNone);
-  add(OclExt::cl_khr_local_int32_base_atomics, CapabilityNone);
-  add(OclExt::cl_khr_local_int32_extended_atomics, CapabilityNone);
-  add(OclExt::cl_khr_byte_addressable_store, CapabilityNone);
-  add(OclExt::cl_khr_3d_image_writes, CapabilityNone);
-  add(OclExt::cl_khr_gl_msaa_sharing, CapabilityNone);
-  add(OclExt::cl_khr_depth_images, CapabilityNone);
-  add(OclExt::cl_khr_gl_depth_images, CapabilityNone);
   add(OclExt::cl_khr_subgroups, CapabilityGroups);
   add(OclExt::cl_khr_mipmap_image, CapabilityImageMipmap);
   add(OclExt::cl_khr_mipmap_image_writes, CapabilityImageMipmap);
-  add(OclExt::cl_khr_egl_event, CapabilityNone);
 }
 
 /// Map OpenCL work functions to SPIR-V builtin variables.

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -61,7 +61,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 7;
+  const static unsigned short kTranslatorVer = 8;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -61,7 +61,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 6;
+  const static unsigned short kTranslatorVer = 7;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -419,7 +419,7 @@ private:
   MDString *transOCLKernelArgTypeName(SPIRVFunctionParameter *);
 
   Value *mapFunction(SPIRVFunction *BF, Function *F) {
-    SPIRVDBG(bildbgs() << "[mapFunction] " << *BF << " -> ";
+    SPIRVDBG(spvdbgs() << "[mapFunction] " << *BF << " -> ";
       dbgs() << *F << '\n';)
     FuncMap[BF] = F;
     return F;
@@ -610,7 +610,7 @@ SPIRVToLLVM::transType(SPIRVType *T) {
   if (Loc != TypeMap.end())
     return Loc->second;
 
-  SPIRVDBG(bildbgs() << "[transType] " << *T << " -> ";)
+  SPIRVDBG(spvdbgs() << "[transType] " << *T << " -> ";)
   T->validate();
   switch(T->getOpCode()) {
   case OpTypeVoid:
@@ -806,7 +806,7 @@ SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
   if (Loc != ValueMap.end() && (!PlaceholderMap.count(BV) || CreatePlaceHolder))
     return Loc->second;
 
-  SPIRVDBG(bildbgs() << "[transValue] " << *BV << " -> ";)
+  SPIRVDBG(spvdbgs() << "[transValue] " << *BV << " -> ";)
   BV->validate();
 
   auto V = transValueWithoutDecoration(BV, F, BB, CreatePlaceHolder);
@@ -853,7 +853,7 @@ SPIRVToLLVM::transConvertInst(SPIRVValue* BV, Function* F, BasicBlock* BB) {
   }
   assert(CastInst::isCast(CO) && "Invalid cast op code");
   SPIRVDBG(if (!CastInst::castIsValid(CO, Src, Dst)) {
-    bildbgs() << "Invalid cast: " << *BV << " -> ";
+    spvdbgs() << "Invalid cast: " << *BV << " -> ";
     dbgs() << "Op = " << CO << ", Src = " << *Src << " Dst = " << *Dst << '\n';
   })
   if (BB)
@@ -1571,7 +1571,7 @@ SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       static_cast<SPIRVInstruction *>(BV), BB));
   }
 
-  SPIRVDBG(bildbgs() << "Cannot translate " << *BV << '\n';)
+  SPIRVDBG(spvdbgs() << "Cannot translate " << *BV << '\n';)
   llvm_unreachable("Translation of SPIRV instruction not implemented");
   return NULL;
   }
@@ -1740,7 +1740,7 @@ SPIRVToLLVM::transBuiltinFromInst(const std::string& FuncName,
       transValue(Ops, BB->getParent(), BB), "", BB);
   setName(Call, BI);
   setAttrByCalledFunc(Call);
-  SPIRVDBG(bildbgs() << "[transInstToBuiltinCall] " << *BI << " -> "; dbgs() <<
+  SPIRVDBG(spvdbgs() << "[transInstToBuiltinCall] " << *BI << " -> "; dbgs() <<
       *Call << '\n';)
   Instruction *Inst = Call;
   Inst = transOCLBuiltinPostproc(BI, Call, BB, FuncName);
@@ -2079,7 +2079,7 @@ SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC, BasicBlock *BB) {
         EntryPoint));
   }
 
-  SPIRVDBG(bildbgs() << "[transOCLBuiltinFromExtInst] OrigUnmangledName: " <<
+  SPIRVDBG(spvdbgs() << "[transOCLBuiltinFromExtInst] OrigUnmangledName: " <<
       UnmangledName << '\n');
   transOCLVectorLoadStore(UnmangledName, BArgs);
 
@@ -2096,7 +2096,7 @@ SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC, BasicBlock *BB) {
   } else {
     MangleOpenCLBuiltin(UnmangledName, ArgTypes, MangledName);
   }
-  SPIRVDBG(bildbgs() << "[transOCLBuiltinFromExtInst] ModifiedUnmangledName: " <<
+  SPIRVDBG(spvdbgs() << "[transOCLBuiltinFromExtInst] ModifiedUnmangledName: " <<
       UnmangledName << " MangledName: " << MangledName << '\n');
 
   FunctionType *FT = FunctionType::get(
@@ -2163,7 +2163,7 @@ SPIRVToLLVM::transOCLBarrierFence(SPIRVInstruction* MB, BasicBlock *BB) {
   auto Call = CallInst::Create(Func, Arg, "", BB);
   setName(Call, MB);
   setAttrByCalledFunc(Call);
-  SPIRVDBG(bildbgs() << "[transBarrier] " << *MB << " -> ";
+  SPIRVDBG(spvdbgs() << "[transBarrier] " << *MB << " -> ";
     dbgs() << *Call << '\n';)
   return Call;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -241,7 +241,7 @@ private:
     }
     ValueMap[V] = BV;
     SPIRVDBG(dbgs() << "[mapValue] " << *V << " => ";
-      bildbgs() << *BV << "\n");
+      spvdbgs() << *BV << "\n");
     return BV;
   }
 
@@ -334,7 +334,7 @@ LLVMToSPIRV::isBuiltinTransToInst(Function *F) {
   if (!oclIsBuiltin(F->getName(), SrcLangVer, &DemangledName) &&
       !isDecoratedSPIRVFunc(F, &DemangledName))
     return false;
-  SPIRVDBG(bildbgs() << "CallInst: demangled name: " << DemangledName << '\n');
+  SPIRVDBG(spvdbgs() << "CallInst: demangled name: " << DemangledName << '\n');
   return getSPIRVFuncOC(DemangledName) != OpNop;
 }
 
@@ -566,7 +566,7 @@ LLVMToSPIRV::transFunctionDecl(Function *F) {
     BF->addDecorate(DecorationFuncParamAttr, FunctionParameterAttributeSext);
   DbgTran.transDbgInfo(F, BF);
   SPIRVDBG(dbgs() << "[transFunction] " << *F << " => ";
-    bildbgs() << *BF << '\n';)
+    spvdbgs() << *BF << '\n';)
   return BF;
 }
 
@@ -1603,7 +1603,7 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
       if (!SPRetTy || !SPRetTy->isTypeStruct())
         return SPI;
       std::vector<SPIRVWord> Mem;
-      SPIRVDBG(bildbgs() << *SPI << '\n');
+      SPIRVDBG(spvdbgs() << *SPI << '\n');
       return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), SPI,
           Mem, BB);
     }

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -59,7 +59,7 @@ extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
 extern bool SPIRVDbgAssertOnError;
 
 // Output stream for SPIRV debug information.
-inline std::ostream& bildbgs() { return std::cerr; }
+inline std::ostream& spvdbgs() { return std::cerr; }
 
 #else
 

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -78,6 +78,10 @@ public:
     Owner = owner;
   }
 
+  SPIRVCapVec getRequiredCapability() const {
+    return getCapability(Dec);
+  }
+
 protected:
   Decoration Dec;
   std::vector<SPIRVWord> Literals;

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -96,13 +96,13 @@ class SPIRVDecorateSet: public std::multiset<const SPIRVDecorateGeneric *,
   iterator insert(const value_type& Dec) {
     auto ER = BaseType::equal_range(Dec);
     for (auto I = ER.first, E = ER.second; I != E; ++I) {
-      SPIRVDBG(bildbgs() << "[compare decorate] " << *Dec
+      SPIRVDBG(spvdbgs() << "[compare decorate] " << *Dec
                         << " vs " << **I << " : ");
       if (**I == *Dec)
         return I;
-      SPIRVDBG(bildbgs() << " diff\n");
+      SPIRVDBG(spvdbgs() << " diff\n");
     }
-    SPIRVDBG(bildbgs() << "[add decorate] " << *Dec << '\n');
+    SPIRVDBG(spvdbgs() << "[add decorate] " << *Dec << '\n');
     return BaseType::insert(Dec);
   }
 };

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -86,7 +86,7 @@ SPIRVEntry::create(Op OpCode) {
   if (Loc != OpToFactoryMap.end())
     return Loc->second();
 
-  SPIRVDBG(bildbgs() << "No factory for OpCode " << (unsigned)OpCode << '\n';)
+  SPIRVDBG(spvdbgs() << "No factory for OpCode " << (unsigned)OpCode << '\n';)
   assert (0 && "Not implemented");
   return 0;
 }
@@ -149,7 +149,7 @@ SPIRVEntry::setWordCount(SPIRVWord TheWordCount){
 void
 SPIRVEntry::setName(const std::string& TheName) {
   Name = TheName;
-  SPIRVDBG(bildbgs() << "Set name for obj " << Id << " " <<
+  SPIRVDBG(spvdbgs() << "Set name for obj " << Id << " " <<
     Name << '\n');
 }
 
@@ -256,7 +256,7 @@ SPIRVEntry::addDecorate(const SPIRVDecorate *Dec){
   auto Kind = Dec->getDecorateKind();
   Decorates.insert(std::make_pair(Dec->getDecorateKind(), Dec));
   Module->addDecorate(Dec);
-  SPIRVDBG(bildbgs() << "[addDecorate] " << *Dec << '\n';)
+  SPIRVDBG(spvdbgs() << "[addDecorate] " << *Dec << '\n';)
 }
 
 void
@@ -277,14 +277,14 @@ SPIRVEntry::eraseDecorate(Decoration Dec){
 void
 SPIRVEntry::takeDecorates(SPIRVEntry *E){
   Decorates = std::move(E->Decorates);
-  SPIRVDBG(bildbgs() << "[takeDecorates] " << Id << '\n';)
+  SPIRVDBG(spvdbgs() << "[takeDecorates] " << Id << '\n';)
 }
 
 void
 SPIRVEntry::setLine(SPIRVLine *L){
   Line = L;
   L->setTargetId(Id);
-  SPIRVDBG(bildbgs() << "[setLine] " << *L << '\n';)
+  SPIRVDBG(spvdbgs() << "[setLine] " << *L << '\n';)
 }
 
 void
@@ -302,7 +302,7 @@ SPIRVEntry::addMemberDecorate(const SPIRVMemberDecorate *Dec){
       MemberDecorates.end());
   MemberDecorates[Dec->getPair()] = Dec;
   Module->addDecorate(Dec);
-  SPIRVDBG(bildbgs() << "[addMemberDecorate] " << *Dec << '\n';)
+  SPIRVDBG(spvdbgs() << "[addMemberDecorate] " << *Dec << '\n';)
 }
 
 void
@@ -324,7 +324,7 @@ SPIRVEntry::eraseMemberDecorate(SPIRVWord MemberNumber, Decoration Dec){
 void
 SPIRVEntry::takeMemberDecorates(SPIRVEntry *E){
   MemberDecorates = std::move(E->MemberDecorates);
-  SPIRVDBG(bildbgs() << "[takeMemberDecorates] " << Id << '\n';)
+  SPIRVDBG(spvdbgs() << "[takeMemberDecorates] " << Id << '\n';)
 }
 
 void

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -187,7 +187,6 @@ class SPIRVExtInst;
 
 class SPIRVEntry {
 public:
-  typedef std::vector<SPIRVCapabilityKind> CapVec;
   enum SPIRVEntryAttrib {
     SPIRVEA_DEFAULT     = 0,
     SPIRVEA_NOID        = 1,      // Entry has no valid id
@@ -240,7 +239,7 @@ public:
   SPIRVLinkageTypeKind getLinkageType() const;
   Op getOpCode() const { return OpCode;}
   SPIRVModule *getModule() const { return Module;}
-  virtual CapVec getRequiredCapability() const { return CapVec();}
+  virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec();}
   const std::string& getName() const { return Name;}
   bool hasDecorate(Decoration Kind, size_t Index = 0,
       SPIRVWord *Result=0)const;
@@ -317,7 +316,7 @@ public:
   virtual void validate()const {
     assert(Module && "Invalid module");
     assert(OpCode != OpNop && "Invalid op code");
-    assert((!hasId() || isValid(Id)) && "Invalid Id");
+    assert((!hasId() || isValidId(Id)) && "Invalid Id");
   }
   void validateFunctionControlMask(SPIRVWord FCtlMask)const;
   void validateValues(const std::vector<SPIRVId> &)const;
@@ -383,7 +382,7 @@ public:
 protected:
   _SPIRV_DEF_ENCDEC0
   void validate()const {
-    assert(isValid(SPIRVEntry::OpCode));
+    assert(isValidId(SPIRVEntry::OpCode));
   }
 };
 
@@ -424,9 +423,6 @@ public:
 protected:
   SPIRVExecutionModelKind ExecModel;
   std::string Name;
-  CapVec getRequiredCapability() const {
-    return getVec(getCapability(ExecModel));
-  }
 };
 
 
@@ -549,8 +545,8 @@ public:
   SPIRVExecutionMode():ExecMode(ExecutionModeCount){}
   SPIRVExecutionModeKind getExecutionMode()const { return ExecMode;}
   const std::vector<SPIRVWord>& getLiterals()const { return WordLiterals;}
-  CapVec getRequiredCapability() const {
-    return getVec(getCapability(ExecMode));
+  SPIRVCapVec getRequiredCapability() const {
+    return getCapability(ExecMode);
   }
 protected:
   _SPIRV_DCL_ENCDEC
@@ -627,7 +623,7 @@ private:
 class SPIRVCapability:public SPIRVEntryNoId<OpCapability> {
 public:
   SPIRVCapability(SPIRVModule *M, SPIRVCapabilityKind K);
-  SPIRVCapability():Kind(CapabilityNone){}
+  SPIRVCapability():Kind(CapabilityMatrix){}
   _SPIRV_DCL_ENCDEC
 private:
   SPIRVCapabilityKind Kind;

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -54,7 +54,7 @@ typedef uint32_t SPIRVId;
 #define SPIRVWORD_MAX     ~0U
 
 inline bool
-isValid(SPIRVId Id) { return Id != SPIRVID_INVALID && Id != 0;}
+isValidId(SPIRVId Id) { return Id != SPIRVID_INVALID && Id != 0;}
 
 inline SPIRVWord
 mkWord(unsigned WordCount, Op OpCode) {
@@ -63,11 +63,6 @@ mkWord(unsigned WordCount, Op OpCode) {
 
 const static unsigned kSPIRVMemOrderSemanticMask = 0x1F;
 
-/// Extract memory order part of SPIR-V memory semantics.
-inline unsigned extractSPIRVMemOrderSemantic(unsigned Sema) {
-  return Sema & kSPIRVMemOrderSemanticMask;
-}
-
 enum SPIRVGeneratorKind {
   SPIRVGEN_KhronosLLVMSPIRVTranslator   = 6,
   SPIRVGEN_KhronosSPIRVAssembler        = 7,
@@ -75,6 +70,26 @@ enum SPIRVGeneratorKind {
 
 enum SPIRVInstructionSchemaKind {
   SPIRVISCH_Default,
+};
+
+enum SPIRVExtInstSetKind {
+  SPIRVEIS_OpenCL,
+  SPIRVEIS_Count,
+};
+
+enum SPIRVSamplerAddressingModeKind {
+  SPIRVSAM_None = 0,
+  SPIRVSAM_ClampEdge = 2,
+  SPIRVSAM_Clamp = 4,
+  SPIRVSAM_Repeat = 6,
+  SPIRVSAM_RepeatMirrored = 8,
+  SPIRVSAM_Invalid = 255,
+};
+
+enum SPIRVSamplerFilterModeKind {
+  SPIRVSFM_Nearest = 16,
+  SPIRVSFM_Linear = 32,
+  SPIRVSFM_Invalid = 255,
 };
 
 typedef spv::Capability SPIRVCapabilityKind;
@@ -92,97 +107,67 @@ typedef spv::BuiltIn SPIRVBuiltinVariableKind;
 typedef spv::MemoryAccessMask SPIRVMemoryAccessKind;
 typedef spv::GroupOperation SPIRVGroupOperationKind;
 typedef spv::Dim SPIRVImageDimKind;
-
-inline bool
-isValid(SPIRVAccessQualifierKind Acc) {
-  return static_cast<unsigned>(Acc) <= AccessQualifierReadWrite;
-}
-
-template<typename K>
-SPIRVCapabilityKind
-getCapability(K Key) {
-  return SPIRVMap<K, SPIRVCapabilityKind>::map(Key);
-}
+typedef std::vector<SPIRVCapabilityKind> SPIRVCapVec;
 
 template<> inline void
-SPIRVMap<SPIRVExecutionModelKind, SPIRVCapabilityKind>::init() {
-  add(ExecutionModelVertex, CapabilityShader);
-  add(ExecutionModelTessellationControl, CapabilityTessellation);
-  add(ExecutionModelTessellationEvaluation, CapabilityShader);
-  add(ExecutionModelGeometry, CapabilityGeometry);
-  add(ExecutionModelFragment, CapabilityShader);
-  add(ExecutionModelGLCompute, CapabilityShader);
-  add(ExecutionModelKernel, CapabilityKernel);
+SPIRVMap<Capability, std::string>::init() {
+  add(CapabilityMatrix, "Matrix");
+  add(CapabilityShader, "Shader");
+  add(CapabilityGeometry, "Geometry");
+  add(CapabilityTessellation, "Tessellation");
+  add(CapabilityAddresses, "Addresses");
+  add(CapabilityLinkage, "Linkage");
+  add(CapabilityKernel, "Kernel");
+  add(CapabilityVector16, "Vector16");
+  add(CapabilityFloat16Buffer, "Float16Buffer");
+  add(CapabilityFloat16, "Float16");
+  add(CapabilityFloat64, "Float64");
+  add(CapabilityInt64, "Int64");
+  add(CapabilityInt64Atomics, "Int64Atomics");
+  add(CapabilityImageBasic, "ImageBasic");
+  add(CapabilityImageReadWrite, "ImageReadWrite");
+  add(CapabilityImageMipmap, "ImageMipmap");
+  add(CapabilityPipes, "Pipes");
+  add(CapabilityGroups, "Groups");
+  add(CapabilityDeviceEnqueue, "DeviceEnqueue");
+  add(CapabilityLiteralSampler, "LiteralSampler");
+  add(CapabilityAtomicStorage, "AtomicStorage");
+  add(CapabilityInt16, "Int16");
+  add(CapabilityTessellationPointSize, "TessellationPointSize");
+  add(CapabilityGeometryPointSize, "GeometryPointSize");
+  add(CapabilityImageGatherExtended, "ImageGatherExtended");
+  add(CapabilityStorageImageMultisample, "StorageImageMultisample");
+  add(CapabilityUniformBufferArrayDynamicIndexing, "UniformBufferArrayDynamicIndexing");
+  add(CapabilitySampledImageArrayDynamicIndexing, "SampledImageArrayDynamicIndexing");
+  add(CapabilityStorageBufferArrayDynamicIndexing, "StorageBufferArrayDynamicIndexing");
+  add(CapabilityStorageImageArrayDynamicIndexing, "StorageImageArrayDynamicIndexing");
+  add(CapabilityClipDistance, "ClipDistance");
+  add(CapabilityCullDistance, "CullDistance");
+  add(CapabilityImageCubeArray, "ImageCubeArray");
+  add(CapabilitySampleRateShading, "SampleRateShading");
+  add(CapabilityImageRect, "ImageRect");
+  add(CapabilitySampledRect, "SampledRect");
+  add(CapabilityGenericPointer, "GenericPointer");
+  add(CapabilityInt8, "Int8");
+  add(CapabilityInputAttachment, "InputAttachment");
+  add(CapabilitySparseResidency, "SparseResidency");
+  add(CapabilityMinLod, "MinLod");
+  add(CapabilitySampled1D, "Sampled1D");
+  add(CapabilityImage1D, "Image1D");
+  add(CapabilitySampledCubeArray, "SampledCubeArray");
+  add(CapabilitySampledBuffer, "SampledBuffer");
+  add(CapabilityImageBuffer, "ImageBuffer");
+  add(CapabilityImageMSArray, "ImageMSArray");
+  add(CapabilityStorageImageExtendedFormats, "StorageImageExtendedFormats");
+  add(CapabilityImageQuery, "ImageQuery");
+  add(CapabilityDerivativeControl, "DerivativeControl");
+  add(CapabilityInterpolationFunction, "InterpolationFunction");
+  add(CapabilityTransformFeedback, "TransformFeedback");
+  add(CapabilityGeometryStreams, "GeometryStreams");
+  add(CapabilityStorageImageReadWithoutFormat, "StorageImageReadWithoutFormat");
+  add(CapabilityStorageImageWriteWithoutFormat, "StorageImageWriteWithoutFormat");
 }
-
-inline bool
-isValid(SPIRVExecutionModelKind E) {
-  return (unsigned)E < (unsigned)ExecutionModelCount;
-}
-
-template<> inline void
-SPIRVMap<SPIRVExecutionModeKind, SPIRVCapabilityKind>::init() {
-  add(ExecutionModeInvocations, CapabilityGeometry);
-  add(ExecutionModeSpacingEqual, CapabilityTessellation);
-  add(ExecutionModeSpacingFractionalEven, CapabilityTessellation);
-  add(ExecutionModeSpacingFractionalOdd, CapabilityTessellation);
-  add(ExecutionModeVertexOrderCw, CapabilityTessellation);
-  add(ExecutionModeVertexOrderCcw, CapabilityTessellation);
-  add(ExecutionModePixelCenterInteger, CapabilityShader);
-  add(ExecutionModeOriginUpperLeft, CapabilityShader);
-  add(ExecutionModeOriginLowerLeft, CapabilityShader);
-  add(ExecutionModeEarlyFragmentTests, CapabilityShader);
-  add(ExecutionModePointMode, CapabilityTessellation);
-  add(ExecutionModeXfb, CapabilityShader);
-  add(ExecutionModeDepthReplacing, CapabilityShader);
-  add(ExecutionModeDepthGreater, CapabilityShader);
-  add(ExecutionModeDepthLess, CapabilityShader);
-  add(ExecutionModeDepthUnchanged, CapabilityShader);
-  add(ExecutionModeLocalSize, CapabilityNone);
-  add(ExecutionModeLocalSizeHint, CapabilityKernel);
-  add(ExecutionModeInputPoints, CapabilityGeometry);
-  add(ExecutionModeInputLines, CapabilityGeometry);
-  add(ExecutionModeInputLinesAdjacency, CapabilityGeometry);
-  add(ExecutionModeTriangles, CapabilityTessellation);
-  add(ExecutionModeInputTrianglesAdjacency, CapabilityGeometry);
-  add(ExecutionModeQuads, CapabilityGeometry);
-  add(ExecutionModeIsolines, CapabilityGeometry);
-  add(ExecutionModeOutputVertices, CapabilityTessellation);
-  add(ExecutionModeOutputPoints, CapabilityGeometry);
-  add(ExecutionModeOutputLineStrip, CapabilityGeometry);
-  add(ExecutionModeOutputTriangleStrip, CapabilityGeometry);
-  add(ExecutionModeVecTypeHint, CapabilityKernel);
-  add(ExecutionModeContractionOff, CapabilityKernel);
-}
-
-inline bool
-isValid(SPIRVExecutionModeKind E) {
-  return (unsigned)E < (unsigned)ExecutionModeCount;
-}
-
-inline bool
-isValid(SPIRVLinkageTypeKind L) {
-  return (unsigned)L < (unsigned)LinkageTypeCount;
-}
-
-template<> inline void
-SPIRVMap<SPIRVStorageClassKind, SPIRVCapabilityKind>::init() {
-  add(StorageClassUniformConstant, CapabilityNone);
-  add(StorageClassInput, CapabilityShader);
-  add(StorageClassUniform, CapabilityShader);
-  add(StorageClassOutput, CapabilityShader);
-  add(StorageClassWorkgroup, CapabilityNone);
-  add(StorageClassCrossWorkgroup, CapabilityNone);
-  add(StorageClassPrivate, CapabilityShader);
-  add(StorageClassFunction, CapabilityShader);
-  add(StorageClassGeneric, CapabilityKernel);
-  add(StorageClassAtomicCounter, CapabilityShader);
-}
-
-inline bool
-isValid(SPIRVStorageClassKind StorageClass) {
-  return (unsigned)StorageClass < (unsigned)StorageClassCount;
-}
+SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 
 template<> inline void
 SPIRVMap<Decoration, std::string>::init() {
@@ -232,32 +217,6 @@ SPIRVMap<Decoration, std::string>::init() {
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorateNameMap)
 
-inline bool
-isValid(SPIRVFuncParamAttrKind FPA) {
-  return (unsigned)FPA < (unsigned)FunctionParameterAttributeCount;
-}
-
-enum SPIRVExtInstSetKind {
-  SPIRVEIS_OpenCL,
-  SPIRVEIS_Count,
-};
-
-inline bool
-isValid(SPIRVExtInstSetKind BIS) {
-  return (unsigned)BIS < (unsigned)SPIRVEIS_Count;
-}
-
-template<> inline void
-SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
-  add(SPIRVEIS_OpenCL, "OpenCL.std");
-}
-typedef SPIRVMap<SPIRVExtInstSetKind, std::string> SPIRVBuiltinSetNameMap;
-
-inline bool
-isValid(SPIRVBuiltinVariableKind Kind) {
-  return (unsigned)Kind < (unsigned)BuiltInCount;
-}
-
 template<> inline void
 SPIRVMap<SPIRVBuiltinVariableKind, std::string>::init() {
   add(BuiltInPosition, "Position");
@@ -304,34 +263,175 @@ SPIRVMap<SPIRVBuiltinVariableKind, std::string>::init() {
 typedef SPIRVMap<SPIRVBuiltinVariableKind, std::string>
   SPIRVBuiltinVariableNameMap;
 
-inline bool isValid(Scope Kind) {
+template<> inline void
+SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
+  add(SPIRVEIS_OpenCL, "OpenCL.std");
+}
+typedef SPIRVMap<SPIRVExtInstSetKind, std::string> SPIRVBuiltinSetNameMap;
+
+inline bool
+isValid(SPIRVAccessQualifierKind Acc) {
+  return static_cast<unsigned>(Acc) <= AccessQualifierReadWrite;
+}
+
+inline bool
+isValid(SPIRVExecutionModelKind E) {
+  return (unsigned)E < (unsigned)ExecutionModelCount;
+}
+
+inline bool
+isValid(SPIRVExecutionModeKind E) {
+  return (unsigned)E < (unsigned)ExecutionModeCount;
+}
+
+inline bool
+isValid(SPIRVLinkageTypeKind L) {
+  return (unsigned)L < (unsigned)LinkageTypeCount;
+}
+
+inline bool
+isValid(SPIRVStorageClassKind StorageClass) {
+  return (unsigned)StorageClass < (unsigned)StorageClassCount;
+}
+
+inline bool
+isValid(SPIRVFuncParamAttrKind FPA) {
+  return (unsigned)FPA < (unsigned)FunctionParameterAttributeCount;
+}
+
+inline bool
+isValid(SPIRVExtInstSetKind BIS) {
+  return (unsigned)BIS < (unsigned)SPIRVEIS_Count;
+}
+
+inline bool
+isValid(SPIRVBuiltinVariableKind Kind) {
+  return (unsigned)Kind < (unsigned)BuiltInCount;
+}
+
+inline bool
+isValid(Scope Kind) {
   return (unsigned)Kind <= (unsigned)ScopeInvocation;
 }
 
-inline bool isValidSPIRVMemSemanticsMask(SPIRVWord MemMask) {
-  return MemMask < 1 << ((unsigned)MemorySemanticsImageMemoryShift + 1);
-}
-
-enum SPIRVSamplerAddressingModeKind {
-  SPIRVSAM_None = 0,
-  SPIRVSAM_ClampEdge = 2,
-  SPIRVSAM_Clamp = 4,
-  SPIRVSAM_Repeat = 6,
-  SPIRVSAM_RepeatMirrored = 8,
-  SPIRVSAM_Invalid = 255,
-};
-
-enum SPIRVSamplerFilterModeKind {
-  SPIRVSFM_Nearest = 16,
-  SPIRVSFM_Linear = 32,
-  SPIRVSFM_Invalid = 255,
-};
-
-inline bool isValid(SPIRVGroupOperationKind G) {
+inline bool
+isValid(SPIRVGroupOperationKind G) {
   return (unsigned)G < (unsigned)GroupOperationCount;
 }
 
-inline unsigned getImageDimension(SPIRVImageDimKind K) {
+template<typename K>
+SPIRVCapVec
+getCapability(K Key) {
+  SPIRVCapVec V;
+  SPIRVCapabilityKind C;
+  if (SPIRVMap<K, SPIRVCapabilityKind>::find(Key, &C))
+    V.push_back(C);
+  return std::move(V);
+}
+
+template<> inline void
+SPIRVMap<SPIRVExecutionModelKind, SPIRVCapabilityKind>::init() {
+  add(ExecutionModelVertex, CapabilityShader);
+  add(ExecutionModelTessellationControl, CapabilityTessellation);
+  add(ExecutionModelTessellationEvaluation, CapabilityShader);
+  add(ExecutionModelGeometry, CapabilityGeometry);
+  add(ExecutionModelFragment, CapabilityShader);
+  add(ExecutionModelGLCompute, CapabilityShader);
+  add(ExecutionModelKernel, CapabilityKernel);
+}
+
+template<> inline void
+SPIRVMap<SPIRVExecutionModeKind, SPIRVCapabilityKind>::init() {
+  add(ExecutionModeInvocations, CapabilityGeometry);
+  add(ExecutionModeSpacingEqual, CapabilityTessellation);
+  add(ExecutionModeSpacingFractionalEven, CapabilityTessellation);
+  add(ExecutionModeSpacingFractionalOdd, CapabilityTessellation);
+  add(ExecutionModeVertexOrderCw, CapabilityTessellation);
+  add(ExecutionModeVertexOrderCcw, CapabilityTessellation);
+  add(ExecutionModePixelCenterInteger, CapabilityShader);
+  add(ExecutionModeOriginUpperLeft, CapabilityShader);
+  add(ExecutionModeOriginLowerLeft, CapabilityShader);
+  add(ExecutionModeEarlyFragmentTests, CapabilityShader);
+  add(ExecutionModePointMode, CapabilityTessellation);
+  add(ExecutionModeXfb, CapabilityShader);
+  add(ExecutionModeDepthReplacing, CapabilityShader);
+  add(ExecutionModeDepthGreater, CapabilityShader);
+  add(ExecutionModeDepthLess, CapabilityShader);
+  add(ExecutionModeDepthUnchanged, CapabilityShader);
+  add(ExecutionModeLocalSizeHint, CapabilityKernel);
+  add(ExecutionModeInputPoints, CapabilityGeometry);
+  add(ExecutionModeInputLines, CapabilityGeometry);
+  add(ExecutionModeInputLinesAdjacency, CapabilityGeometry);
+  add(ExecutionModeTriangles, CapabilityTessellation);
+  add(ExecutionModeInputTrianglesAdjacency, CapabilityGeometry);
+  add(ExecutionModeQuads, CapabilityGeometry);
+  add(ExecutionModeIsolines, CapabilityGeometry);
+  add(ExecutionModeOutputVertices, CapabilityTessellation);
+  add(ExecutionModeOutputPoints, CapabilityGeometry);
+  add(ExecutionModeOutputLineStrip, CapabilityGeometry);
+  add(ExecutionModeOutputTriangleStrip, CapabilityGeometry);
+  add(ExecutionModeVecTypeHint, CapabilityKernel);
+  add(ExecutionModeContractionOff, CapabilityKernel);
+}
+
+template<> inline void
+SPIRVMap<SPIRVStorageClassKind, SPIRVCapabilityKind>::init() {
+  add(StorageClassInput, CapabilityShader);
+  add(StorageClassUniform, CapabilityShader);
+  add(StorageClassOutput, CapabilityShader);
+  add(StorageClassPrivate, CapabilityShader);
+  add(StorageClassFunction, CapabilityShader);
+  add(StorageClassGeneric, CapabilityKernel);
+  add(StorageClassAtomicCounter, CapabilityShader);
+}
+
+template<> inline void
+SPIRVMap<Decoration, SPIRVCapabilityKind>::init() {
+  add(DecorationRelaxedPrecision, CapabilityShader);
+  add(DecorationSpecId, CapabilityShader);
+  add(DecorationBlock, CapabilityShader);
+  add(DecorationBufferBlock, CapabilityShader);
+  add(DecorationRowMajor, CapabilityShader);
+  add(DecorationColMajor, CapabilityShader);
+  add(DecorationArrayStride, CapabilityShader);
+  add(DecorationMatrixStride, CapabilityShader);
+  add(DecorationGLSLShared, CapabilityShader);
+  add(DecorationGLSLPacked, CapabilityShader);
+  add(DecorationCPacked, CapabilityKernel);
+  add(DecorationBuiltIn, CapabilityShader);
+  add(DecorationNoPerspective, CapabilityShader);
+  add(DecorationFlat, CapabilityShader);
+  add(DecorationPatch, CapabilityTessellation);
+  add(DecorationCentroid, CapabilityShader);
+  add(DecorationSample, CapabilityShader);
+  add(DecorationInvariant, CapabilityShader);
+  add(DecorationConstant, CapabilityShader);
+  add(DecorationUniform, CapabilityShader);
+  add(DecorationSaturatedConversion, CapabilityKernel);
+  add(DecorationStream, CapabilityGeometryStreams);
+  add(DecorationLocation, CapabilityShader);
+  add(DecorationComponent, CapabilityShader);
+  add(DecorationIndex, CapabilityShader);
+  add(DecorationBinding, CapabilityShader);
+  add(DecorationDescriptorSet, CapabilityShader);
+  add(DecorationXfbBuffer, CapabilityTransformFeedback);
+  add(DecorationXfbStride, CapabilityTransformFeedback);
+  add(DecorationFuncParamAttr, CapabilityKernel);
+  add(DecorationFPRoundingMode, CapabilityKernel);
+  add(DecorationFPFastMathMode, CapabilityKernel);
+  add(DecorationLinkageAttributes, CapabilityLinkage);
+  add(DecorationNoContraction, CapabilityShader);
+  add(DecorationInputAttachmentIndex, CapabilityInputAttachment);
+  add(DecorationAlignment, CapabilityKernel);
+}
+
+inline bool
+isValidSPIRVMemSemanticsMask(SPIRVWord MemMask) {
+  return MemMask < 1 << ((unsigned)MemorySemanticsImageMemoryShift + 1);
+}
+
+inline unsigned
+getImageDimension(SPIRVImageDimKind K) {
   switch(K){
   case Dim1D:      return 1;
   case Dim2D:      return 2;
@@ -342,6 +442,13 @@ inline unsigned getImageDimension(SPIRVImageDimKind K) {
   default:              return 0;
   }
 }
+
+/// Extract memory order part of SPIR-V memory semantics.
+inline unsigned
+extractSPIRVMemOrderSemantic(unsigned Sema) {
+  return Sema & kSPIRVMemOrderSemanticMask;
+}
+
 
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -1,4 +1,4 @@
-//===- SPIRVEnum.h - SPIR-V enums --------------------------------*- C++ -*-===//
+//===- SPIRVEnum.h - SPIR-V enums -------------------------------*- C++ -*-===//
 //
 //                     The LLVM/SPIRV Translator
 //
@@ -391,21 +391,20 @@ SPIRVMap<Decoration, SPIRVCapabilityKind>::init() {
   add(DecorationSpecId, CapabilityShader);
   add(DecorationBlock, CapabilityShader);
   add(DecorationBufferBlock, CapabilityShader);
-  add(DecorationRowMajor, CapabilityShader);
-  add(DecorationColMajor, CapabilityShader);
+  add(DecorationRowMajor, CapabilityMatrix);
+  add(DecorationColMajor, CapabilityMatrix);
   add(DecorationArrayStride, CapabilityShader);
   add(DecorationMatrixStride, CapabilityShader);
   add(DecorationGLSLShared, CapabilityShader);
   add(DecorationGLSLPacked, CapabilityShader);
   add(DecorationCPacked, CapabilityKernel);
-  add(DecorationBuiltIn, CapabilityShader);
   add(DecorationNoPerspective, CapabilityShader);
   add(DecorationFlat, CapabilityShader);
   add(DecorationPatch, CapabilityTessellation);
   add(DecorationCentroid, CapabilityShader);
   add(DecorationSample, CapabilityShader);
   add(DecorationInvariant, CapabilityShader);
-  add(DecorationConstant, CapabilityShader);
+  add(DecorationConstant, CapabilityKernel);
   add(DecorationUniform, CapabilityShader);
   add(DecorationSaturatedConversion, CapabilityKernel);
   add(DecorationStream, CapabilityGeometryStreams);

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -114,8 +114,8 @@ SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
     SS <<" [Src: " << FileName << ":" << LineNo << " " << CondString << " ]";
   setError(ErrCode, SS.str());
   if (SPIRVDbgAssertOnError) {
-    bildbgs() << SS.str() << '\n';
-    bildbgs().flush();
+    spvdbgs() << SS.str() << '\n';
+    spvdbgs().flush();
     assert (0);
   }
   return Cond;

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -99,7 +99,7 @@ SPIRVFunction::decode(std::istream &I) {
   SPIRVDecoder Decoder = getDecoder(I);
   Decoder >> Type >> Id >> FCtrlMask >> FuncType;
   Module->addFunction(this);
-  SPIRVDBG(bildbgs() << "Decode function: " << Id << '\n');
+  SPIRVDBG(spvdbgs() << "Decode function: " << Id << '\n');
 
   Decoder.getWordCountAndOpCode();
   while (!I.eof()) {
@@ -131,7 +131,7 @@ void
 SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
   SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock*>(Decoder.getEntry());
   addBasicBlock(BB);
-  SPIRVDBG(bildbgs() << "Decode BB: " << BB->getId() << '\n');
+  SPIRVDBG(spvdbgs() << "Decode BB: " << BB->getId() << '\n');
 
   Decoder.setScope(BB);
   while(Decoder.getWordCountAndOpCode()) {

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -64,10 +64,10 @@ public:
   }
   bool isByVal()const { return hasAttr(FunctionParameterAttributeByVal);}
   bool isZext()const { return hasAttr(FunctionParameterAttributeZext);}
-  CapVec getRequiredCapability() const {
+  SPIRVCapVec getRequiredCapability() const {
     if (hasLinkageType() && getLinkageType() == LinkageTypeImport)
       return getVec(CapabilityLinkage);
-    return CapVec();
+    return SPIRVCapVec();
   }
 protected:
   void validate()const {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1696,7 +1696,7 @@ enum SPIRVOpKind {
 
 class SPIRVDevEnqInstBase:public SPIRVInstTemplateBase {
 public:
-  CapVec getRequiriedCapability() const {
+  SPIRVCapVec getRequiriedCapability() const {
     return getVec(CapabilityDeviceEnqueue);
   }
 };
@@ -1723,7 +1723,7 @@ _SPIRV_OP(BuildNDRange, true, 6)
 
 class SPIRVPipeInstBase:public SPIRVInstTemplateBase {
 public:
-  CapVec getRequiriedCapability() const {
+  SPIRVCapVec getRequiriedCapability() const {
     return getVec(CapabilityPipes);
   }
 };
@@ -1747,7 +1747,7 @@ _SPIRV_OP(GetMaxPipePackets, true, 6)
 
 class SPIRVGroupInstBase:public SPIRVInstTemplateBase {
 public:
-  CapVec getRequiriedCapability() const {
+  SPIRVCapVec getRequiriedCapability() const {
     return getVec(CapabilityGroups);
   }
 };
@@ -1776,7 +1776,7 @@ _SPIRV_OP(GroupCommitWritePipe, false, 6)
 
 class SPIRVAtomicInstBase:public SPIRVInstTemplateBase {
 public:
-  CapVec getRequiriedCapability() const {
+  SPIRVCapVec getRequiriedCapability() const {
     return getVec(CapabilityInt64Atomics);
   }
 };
@@ -1808,7 +1808,7 @@ _SPIRV_OP(MemoryBarrier, false, 3)
 
 class SPIRVImageInstBase:public SPIRVInstTemplateBase {
 public:
-  CapVec getRequiriedCapability() const {
+  SPIRVCapVec getRequiriedCapability() const {
     return getVec(CapabilityImageBasic);
   }
 };

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -365,28 +365,28 @@ SPIRVModuleImpl::addLine(SPIRVEntry* E, SPIRVString* FileName,
 // multiple targets.
 void
 SPIRVModuleImpl::optimizeDecorates() {
-  SPIRVDBG(bildbgs() << "[optimizeDecorates] begin\n");
+  SPIRVDBG(spvdbgs() << "[optimizeDecorates] begin\n");
   for (auto I = DecorateSet.begin(), E = DecorateSet.end(); I != E;) {
     auto D = *I;
-    SPIRVDBG(bildbgs() << "  check " << *D << '\n');
+    SPIRVDBG(spvdbgs() << "  check " << *D << '\n');
     if (D->getOpCode() == OpMemberDecorate) {
       ++I;
       continue;
     }
     auto ER = DecorateSet.equal_range(D);
-    SPIRVDBG(bildbgs() << "  equal range " << **ER.first
+    SPIRVDBG(spvdbgs() << "  equal range " << **ER.first
                       << " to ";
             if (ER.second != DecorateSet.end())
-              bildbgs() << **ER.second;
+              spvdbgs() << **ER.second;
             else
-              bildbgs() << "end";
-            bildbgs() << '\n');
+              spvdbgs() << "end";
+            spvdbgs() << '\n');
     if (std::distance(ER.first, ER.second) < 2) {
       I = ER.second;
-      SPIRVDBG(bildbgs() << "  skip equal range \n");
+      SPIRVDBG(spvdbgs() << "  skip equal range \n");
       continue;
     }
-    SPIRVDBG(bildbgs() << "  add deco group. erase equal range\n");
+    SPIRVDBG(spvdbgs() << "  add deco group. erase equal range\n");
     auto G = new SPIRVDecorationGroup(this, getId());
     std::vector<SPIRVId> Targets;
     Targets.push_back(D->getTargetId());
@@ -414,6 +414,7 @@ SPIRVModuleImpl::addSamplerConstant(SPIRVType* TheType,
 
 void
 SPIRVModuleImpl::addCapability(SPIRVCapabilityKind Cap) {
+  SPIRVDBG(spvdbgs() << "addCapability: " << Cap << '\n');
   CapSet.insert(Cap);
 }
 
@@ -1152,8 +1153,8 @@ SPIRVModuleImpl::addDecorationGroup(SPIRVDecorationGroup* Group) {
   add(Group);
   Group->takeDecorates(DecorateSet);
   DecGroupVec.push_back(Group);
-  SPIRVDBG(bildbgs() << "[addDecorationGroup] {" << *Group << "}\n";
-          bildbgs() << "  Remaining DecorateSet: {" << DecorateSet << "}\n");
+  SPIRVDBG(spvdbgs() << "[addDecorationGroup] {" << *Group << "}\n";
+          spvdbgs() << "  Remaining DecorateSet: {" << DecorateSet << "}\n");
   assert(DecorateSet.empty());
   return Group;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -112,7 +112,7 @@ public:
   virtual std::set<std::string> &getExtension() = 0;
   virtual SPIRVFunction *getFunction(unsigned) const = 0;
   virtual SPIRVVariable *getVariable(unsigned) const = 0;
-  virtual SPIRVMemoryModelKind getMemoryModel() = 0;
+  virtual SPIRVMemoryModelKind getMemoryModel() const = 0;
   virtual unsigned getNumFunctions() const = 0;
   virtual unsigned getNumEntryPoints(SPIRVExecutionModelKind) const = 0;
   virtual unsigned getNumVariables() const = 0;
@@ -225,6 +225,11 @@ public:
   virtual SPIRVInstruction *addExtInst(SPIRVType *, SPIRVWord, SPIRVWord,
       const std::vector<SPIRVValue *> &, SPIRVBasicBlock *) = 0;
   virtual void addCapability(SPIRVCapabilityKind) = 0;
+  template<typename T>
+  void addCapabilities(const T& Caps) {
+    for (auto I: Caps)
+      addCapability(I);
+  }
   /// Used by SPIRV entries to add required capability internally.
   /// Should not be used by users directly.
   virtual void addCapabilityInternal(SPIRVCapabilityKind) = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -105,7 +105,7 @@ decode(const SPIRVDecoder& I, T &V) {
     std::string W;
     I.IS >> W;
     V = getNameMap(V).rmap(W);
-    SPIRVDBG(bildbgs() << "Read word: W = " << W << " V = " << V << '\n');
+    SPIRVDBG(spvdbgs() << "Read word: W = " << W << " V = " << V << '\n');
     return I;
   }
 #endif
@@ -146,7 +146,7 @@ operator>>(const SPIRVDecoder&I, std::string& Str) {
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (SPIRVUseTextFormat) {
     readQuotedString(I.IS, Str);
-    SPIRVDBG(bildbgs() << "Read string: \"" << Str << "\"\n");
+    SPIRVDBG(spvdbgs() << "Read string: \"" << Str << "\"\n");
     return I;
   }
 #endif
@@ -163,7 +163,7 @@ operator>>(const SPIRVDecoder&I, std::string& Str) {
     I.IS >> Ch;
     assert(Ch == '\0' && "Invalid string in SPIRV");
   }
-  SPIRVDBG(bildbgs() << "Read string: \"" << Str << "\"\n");
+  SPIRVDBG(spvdbgs() << "Read string: \"" << Str << "\"\n");
   return I;
 }
 
@@ -190,7 +190,7 @@ SPIRVDecoder::getWordCountAndOpCode() {
   if (IS.eof()) {
     WordCount = 0;
     OpCode = OpNop;
-    SPIRVDBG(bildbgs() << "[SPIRVDecoder] getWordCountAndOpCode EOF " <<
+    SPIRVDBG(spvdbgs() << "[SPIRVDecoder] getWordCountAndOpCode EOF " <<
         WordCount << " " << OpCode << '\n');
     return false;
   }
@@ -201,7 +201,7 @@ SPIRVDecoder::getWordCountAndOpCode() {
     if (IS.fail()) {
       WordCount = 0;
       OpCode = OpNop;
-      SPIRVDBG(bildbgs() << "[SPIRVDecoder] getWordCountAndOpCode FAIL " <<
+      SPIRVDBG(spvdbgs() << "[SPIRVDecoder] getWordCountAndOpCode FAIL " <<
           WordCount << " " << OpCode << '\n');
       return false;
     }
@@ -219,11 +219,11 @@ SPIRVDecoder::getWordCountAndOpCode() {
   if (IS.fail()) {
     WordCount = 0;
     OpCode = OpNop;
-    SPIRVDBG(bildbgs() << "[SPIRVDecoder] getWordCountAndOpCode FAIL " <<
+    SPIRVDBG(spvdbgs() << "[SPIRVDecoder] getWordCountAndOpCode FAIL " <<
         WordCount << " " << OpCode << '\n');
     return false;
   }
-  SPIRVDBG(bildbgs() << "[SPIRVDecoder] getWordCountAndOpCode " << WordCount <<
+  SPIRVDBG(spvdbgs() << "[SPIRVDecoder] getWordCountAndOpCode " << WordCount <<
       " " << OpCodeNameMap::map(OpCode) << '\n');
   return true;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -135,6 +135,7 @@ operator<<(const SPIRVEncoder& O, Type V) { \
 }
 
 SPIRV_DEF_ENCDEC(Op)
+SPIRV_DEF_ENCDEC(Capability)
 SPIRV_DEF_ENCDEC(Decoration)
 SPIRV_DEF_ENCDEC(OCLExtOpKind)
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -100,7 +100,7 @@ DecodeBinary(const SPIRVDecoder& I, T &V) {
   uint32_t W;
   I.IS.read(reinterpret_cast<char*>(&W), sizeof(W));
   V = static_cast<T>(W);
-  SPIRVDBG(bildbgs() << "Read word: W = " << W << " V = " << V << '\n');
+  SPIRVDBG(spvdbgs() << "Read word: W = " << W << " V = " << V << '\n');
   return I;
 }
 
@@ -112,7 +112,7 @@ operator>>(const SPIRVDecoder& I, T &V) {
     uint32_t W;
     I.IS >> W;
     V = static_cast<T>(W);
-    SPIRVDBG(bildbgs() << "Read word: W = " << W << " V = " << V << '\n');
+    SPIRVDBG(spvdbgs() << "Read word: W = " << W << " V = " << V << '\n');
     return I;
   }
 #endif

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -187,6 +187,7 @@ const SPIRVDecoder& \
 operator>>(const SPIRVDecoder& I, Type &V);
 
 SPIRV_DEC_ENCDEC(Op)
+SPIRV_DEC_ENCDEC(Capability)
 SPIRV_DEC_ENCDEC(Decoration)
 SPIRV_DEC_ENCDEC(OCLExtOpKind)
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -189,11 +189,12 @@ public:
 
   SPIRVType *getElementType() const { return ElemType;}
   SPIRVStorageClassKind getStorageClass() const { return StorageClass;}
-  CapVec getRequiredCapability() const {
+  SPIRVCapVec getRequiredCapability() const {
     auto Cap = getVec(CapabilityAddresses);
     if (ElemType->isTypeFloat(16))
       Cap.push_back(CapabilityFloat16Buffer);
-    Cap.push_back(getCapability(StorageClass));
+    auto C = getCapability(StorageClass);
+    Cap.insert(Cap.end(), C.begin(), C.end());
     return Cap;
   }
 protected:
@@ -224,10 +225,10 @@ public:
   SPIRVType *getComponentType() const { return CompType;}
   SPIRVWord getComponentCount() const { return CompCount;}
   bool isValidIndex(SPIRVWord Index) const { return Index < CompCount;}
-  CapVec getRequiredCapability() const {
+  SPIRVCapVec getRequiredCapability() const {
     if (CompCount >= 8)
       return getVec(CapabilityVector16);
-    return CapVec();
+    return SPIRVCapVec();
   }
 
 protected:
@@ -365,8 +366,8 @@ public:
     assert(hasAccessQualifier());
     return Acc[0];
   }
-  CapVec getRequiredCapability() const {
-    CapVec CV;
+  SPIRVCapVec getRequiredCapability() const {
+    SPIRVCapVec CV;
     CV.push_back(CapabilityImageBasic);
     if (Acc.size() > 0 && Acc[0] == AccessQualifierReadWrite)
       CV.push_back(CapabilityImageReadWrite);
@@ -565,13 +566,13 @@ public:
     AccessQualifier(AccessQualifierReadOnly){}
 
   SPIRVAccessQualifierKind getAccessQualifier() const {
-      return AccessQualifier; 
+      return AccessQualifier;
   }
   void setPipeAcessQualifier(SPIRVAccessQualifierKind AccessQual) {
     AccessQualifier = AccessQual;
     assert(isValid(AccessQualifier));
   }
-  CapVec getRequiredCapability() const {
+  SPIRVCapVec getRequiredCapability() const {
     return getVec(CapabilityPipes);
   }
 protected:

--- a/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -50,7 +50,7 @@ SPIRVValue::setAlignment(SPIRVWord A) {
     return;
   }
   addDecorate(new SPIRVDecorate(DecorationAlignment, this, A));
-  SPIRVDBG(bildbgs() << "Set alignment " << A << " for obj " << Id << "\n")
+  SPIRVDBG(spvdbgs() << "Set alignment " << A << " for obj " << Id << "\n")
 }
 
 bool
@@ -70,7 +70,7 @@ SPIRVValue::setVolatile(bool IsVolatile) {
     return;
   }
   addDecorate(new SPIRVDecorate(DecorationVolatile, this));
-  SPIRVDBG(bildbgs() << "Set volatile " << " for obj " << Id << "\n")
+  SPIRVDBG(spvdbgs() << "Set volatile " << " for obj " << Id << "\n")
 }
 
 }

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -110,8 +110,8 @@ public:
       setHasNoType();
   }
 
-  CapVec getRequiredCapability() const {
-    CapVec CV;
+  SPIRVCapVec getRequiredCapability() const {
+    SPIRVCapVec CV;
     if (!hasType())
       return CV;
     if (Type->isTypeFloat(16))
@@ -328,7 +328,7 @@ public:
   SPIRVWord getNormalized() const {
     return Normalized;
   }
-  CapVec getRequiredCapability() const {
+  SPIRVCapVec getRequiredCapability() const {
     return getVec(CapabilityLiteralSampler);
   }
 protected:

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -113,16 +113,8 @@ public:
   SPIRVCapVec getRequiredCapability() const {
     SPIRVCapVec CV;
     if (!hasType())
-      return CV;
-    if (Type->isTypeFloat(16))
-      CV.push_back(CapabilityFloat16);
-    else if (Type->isTypeFloat(64))
-      CV.push_back(CapabilityFloat64);
-    else if (Type->isTypeInt(16))
-      CV.push_back(CapabilityInt16);
-    else if (Type->isTypeInt(64))
-      CV.push_back(CapabilityInt64);
-    return CV;
+      return std::move(CV);
+    return std::move(Type->getRequiredCapability());
   }
 
 protected:

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -575,8 +575,7 @@ enum Capability {
     CapabilityTransformFeedback = 53,
     CapabilityGeometryStreams = 54,
     CapabilityStorageImageReadWithoutFormat = 55,
-    CapabilityStorageImageWriteWithoutFormat = 56,
-    CapabilityNone = 1024, /* internal use only */
+    CapabilityStorageImageWriteWithoutFormat = 56
 };
 
 enum Op {

--- a/test/SPIRV/capbility-kernel.ll
+++ b/test/SPIRV/capbility-kernel.ll
@@ -1,0 +1,53 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: FileCheck < %t %s
+
+; CHECK-DAG: {{[0-9]*}} Capability Addresses
+
+; ModuleID = 'capbility-kernel.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-DAG: {{[0-9]*}} Capability Linkage
+; Function Attrs: nounwind
+define spir_func void @func_export(i32 addrspace(1)* nocapture %a) #0 {
+entry:
+  store i32 1, i32 addrspace(1)* %a, align 4, !tbaa !9
+  ret void
+}
+
+; CHECK-DAG: {{[0-9]*}} Capability Kernel
+; Function Attrs: nounwind
+define spir_kernel void @func_kernel(i32 addrspace(1)* %a) #0 {
+entry:
+  tail call spir_func void @func_import(i32 addrspace(1)* %a) #2
+  ret void
+}
+
+declare spir_func void @func_import(i32 addrspace(1)*) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!7}
+!opencl.compiler.options = !{!7}
+!llvm.ident = !{!8}
+
+!0 = !{void (i32 addrspace(1)*)* @func_kernel, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_type_qual", !""}
+!5 = !{!"kernel_arg_base_type", !"int*"}
+!6 = !{i32 2, i32 0}
+!7 = !{}
+!8 = !{!"clang version 3.4 "}
+!9 = !{!10, !10, i64 0}
+!10 = !{!"int", !11, i64 0}
+!11 = !{!"omnipotent char", !12, i64 0}
+!12 = !{!"Simple C/C++ TBAA"}

--- a/test/SPIRV/capbility-kernel.ll
+++ b/test/SPIRV/capbility-kernel.ll
@@ -11,23 +11,39 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_func void @func_export(i32 addrspace(1)* nocapture %a) #0 {
 entry:
+; CHECK-DAG: {{[0-9]*}} Capability Int64
+  %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
+  %cmp = icmp eq i64 %call, 0
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
   store i32 1, i32 addrspace(1)* %a, align 4, !tbaa !9
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
   ret void
 }
 
+; Function Attrs: nounwind readnone
+declare spir_func i64 @_Z13get_global_idj(i32) #1
+
 ; CHECK-DAG: {{[0-9]*}} Capability Kernel
+; CHECK-NOT: {{[0-9]*}} Capability Shader
+; CHECK-NOT: {{[0-9]*}} Capability Float64
 ; Function Attrs: nounwind
 define spir_kernel void @func_kernel(i32 addrspace(1)* %a) #0 {
 entry:
-  tail call spir_func void @func_import(i32 addrspace(1)* %a) #2
+  tail call spir_func void @func_import(i32 addrspace(1)* %a) #4
   ret void
 }
 
-declare spir_func void @func_import(i32 addrspace(1)*) #1
+declare spir_func void @func_import(i32 addrspace(1)*) #2
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind }
+attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind readnone }
+attributes #4 = { nounwind }
 
 !opencl.kernels = !{!0}
 !opencl.enable.FP_CONTRACT = !{}


### PR DESCRIPTION
…ded to SPIR-V.

When generating a SPIR-V binary from the sames files as in #3 (LLVM code and OpenCL kernel), noOpCapability Kernel is generated (required by OpEntryPoint Kernel, OpMemoryModel OpenCL, OpDecorate FuncParamAttr, OpDecorate Constant), nor OpCapability Linkage, which is required by OpDecorate LinkageAttributes.

Add capability when adding entry points to module.
Add required capability for decorations.
Refactor getCapability() so that empty capability can be returned.
Removed CapabilityNone.
Add name map for Capability.
Rename isValid(SPIRVId) to isValidId for clarity since SPIRVId is just typedef of uint32_t.
Reorder name maps and isValid functions in SPIRVEnum.h for further auto generation.
Add lit test for CapabilityKernel and CapabilityLinkage.
