### PR TITLE
Khronos/spirv 3.6.1 out

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -269,16 +269,27 @@ public:
     }
   } else if (UnmangledName.find("atomic") == 0) {
     setArgAttr(0, SPIR::ATTR_VOLATILE);
-    addAtomicArg(0);
     if (UnmangledName.find("atomic_umax") == 0 ||
         UnmangledName.find("atomic_umin") == 0) {
       addUnsignedArg(0);
+      addUnsignedArg(1);
       UnmangledName.erase(7, 1);
     } else if (UnmangledName.find("atomic_fetch_umin") == 0 ||
                UnmangledName.find("atomic_fetch_umax") == 0) {
       addUnsignedArg(0);
+      addUnsignedArg(1);
       UnmangledName.erase(13, 1);
     }
+    // Don't set atomic property to the first argument of 1.2 atomic built-ins.
+    if(UnmangledName.find("atomic_add")  != 0 && UnmangledName.find("atomic_sub") != 0 &&
+       UnmangledName.find("atomic_xchg") != 0 && UnmangledName.find("atomic_inc") != 0 &&
+       UnmangledName.find("atomic_dec")  != 0 && UnmangledName.find("atomic_cmpxchg") != 0 &&
+       UnmangledName.find("atomic_min")  != 0 && UnmangledName.find("atomic_max") != 0 &&
+       UnmangledName.find("atomic_and")  != 0 && UnmangledName.find("atomic_or") != 0 &&
+       UnmangledName.find("atomic_xor")  != 0 && UnmangledName.find("atom_") != 0) {
+      addAtomicArg(0);
+    }
+
   } else if (UnmangledName.find("uconvert_") == 0) {
     addUnsignedArg(0);
     UnmangledName.erase(0, 1);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1561,7 +1561,11 @@ SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     } else if (isCvtOpCode(OC)) {
         auto BI = static_cast<SPIRVInstruction *>(BV);
         Value *Inst = nullptr;
-        if (BI->hasFPRoundingMode() || BI->isSaturatedConversion())
+        // Vector casts are prohibited in OpenCL; such casts may not be translated
+        // into LLVM instructions directly. OpenCL C/C++ has special convertion
+        // functions which are to be used instead.
+        const bool isVectorCast = BI->getOperandTypes()[0]->isTypeVector();
+        if (isVectorCast || BI->hasFPRoundingMode() || BI->isSaturatedConversion())
           Inst = transOCLBuiltinFromInst(BI, BB);
         else
           Inst = transConvertInst(BV, F, BB);

--- a/test/SPIRV/transcoding/atomics_1.2.ll
+++ b/test/SPIRV/transcoding/atomics_1.2.ll
@@ -1,0 +1,232 @@
+; ModuleID = 'atomics_1.2'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; Check the mangling of 1.2 atomic functions. This test expects what
+; most of the built-ins are promoted to OpenCL C 2.0 atomics.
+; Most of atomics lost information about the sign of the integer operand
+; but since this concerns only built-ins  with two-complement's ariphmetics
+; it shouldn't cause any problems.
+
+; CHECK: _Z10atomic_incPVU3AS1i
+; CHECK: _Z10atomic_incPVU3AS1i
+; CHECK: _Z25atomic_fetch_max_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_max_explicitPVU3AS1U7_Atomicjjii
+; CHECK: _Z25atomic_fetch_min_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_min_explicitPVU3AS1U7_Atomicjjii
+; CHECK: _Z25atomic_fetch_add_explicitPVU3AS1U7_A
+; CHECK: _Z25atomic_fetch_add_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_sub_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_sub_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z24atomic_fetch_or_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z24atomic_fetch_or_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_xor_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_xor_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_and_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_and_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z39atomic_compare_exchange_strong_explicitPVU3AS1U7
+; CHECK: _Z39atomic_compare_exchange_strong_explicitPVU3AS1U7
+; CHECK: _Z24atomic_exchange_explicitPVU3AS1U7_Atomiciiii
+; CHECK: _Z24atomic_exchange_explicitPVU3AS1U7_Atomiciiii
+
+; Function Attrs: nounwind
+define spir_kernel void @test_atomic_global(i32 addrspace(1)* %dst) #0 {
+  ; atomic_inc
+  %inc_ig = tail call spir_func i32 @_Z10atomic_incPVU3AS1i(i32 addrspace(1)* %dst) #0
+  %inc_jg = tail call spir_func i32 @_Z10atomic_incPVU3AS1j(i32 addrspace(1)* %dst) #0
+  ; atomic_max
+  %max_ig = tail call spir_func i32 @_Z10atomic_maxPVU3AS1ii(i32 addrspace(1)* %dst, i32 0) #0
+  %max_jg = tail call spir_func i32 @_Z10atomic_maxPVU3AS1jj(i32 addrspace(1)* %dst, i32 0) #0
+  ; atomic_min
+  %min_ig = tail call spir_func i32 @_Z10atomic_minPVU3AS1ii(i32 addrspace(1)* %dst, i32 0) #0
+  %min_jg = tail call spir_func i32 @_Z10atomic_minPVU3AS1jj(i32 addrspace(1)* %dst, i32 0) #0
+  ; atomic_add
+  %add_ig = tail call spir_func i32 @_Z10atomic_addPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %add_jg = tail call spir_func i32 @_Z10atomic_addPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ; atomic_sub
+  %sub_ig = tail call spir_func i32 @_Z10atomic_subPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %sub_jg = tail call spir_func i32 @_Z10atomic_subPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ; atomic_or
+  %or_ig = tail call spir_func i32 @_Z9atomic_orPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %or_jg = tail call spir_func i32 @_Z9atomic_orPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ; atomic_xor
+  %xor_ig = tail call spir_func i32 @_Z10atomic_xorPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %xor_jg = tail call spir_func i32 @_Z10atomic_xorPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ; atomic_and
+  %and_ig = tail call spir_func i32 @_Z10atomic_andPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %and_jg = tail call spir_func i32 @_Z10atomic_andPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ; atomic_cmpxchg
+  %cmpxchg_ig = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)* %dst, i32 0, i32 1) #0
+  %cmpxchg_jg = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1jjj(i32 addrspace(1)* %dst, i32 0, i32 1) #0
+  ; atomic_xchg
+  %xchg_ig = call spir_func i32 @_Z11atomic_xchgPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
+  %xchg_jg = call spir_func i32 @_Z11atomic_xchgPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func i32 @_Z10atomic_incPVU3AS1i(i32 addrspace(1)*)
+
+declare spir_func i32 @_Z10atomic_incPVU3AS1j(i32 addrspace(1)*)
+
+declare spir_func i32 @_Z10atomic_maxPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_maxPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_minPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_minPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_addPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_addPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_subPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_subPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z9atomic_orPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z9atomic_orPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_xorPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_xorPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_andPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z10atomic_andPVU3AS1jj(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)*, i32, i32)
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS1jjj(i32 addrspace(1)*, i32, i32)
+
+declare spir_func i32 @_Z11atomic_xchgPVU3AS1ii(i32 addrspace(1)*, i32)
+
+declare spir_func i32 @_Z11atomic_xchgPVU3AS1jj(i32 addrspace(1)*, i32)
+
+; CHECK: _Z10atomic_incPVU3AS3i
+; CHECK: _Z10atomic_incPVU3AS3i
+; CHECK: _Z25atomic_fetch_max_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_max_explicitPVU3AS3U7_Atomicjjii
+; CHECK: _Z25atomic_fetch_min_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_min_explicitPVU3AS3U7_Atomicjjii
+; CHECK: _Z25atomic_fetch_add_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_add_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_sub_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_sub_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z24atomic_fetch_or_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z24atomic_fetch_or_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_xor_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_xor_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_and_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z25atomic_fetch_and_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z39atomic_compare_exchange_strong_explicitPVU3AS3U7
+; CHECK: _Z39atomic_compare_exchange_strong_explicitPVU3AS3U7
+; CHECK: _Z24atomic_exchange_explicitPVU3AS3U7_Atomiciiii
+; CHECK: _Z24atomic_exchange_explicitPVU3AS3U7_Atomiciiii
+
+; Function Attrs: nounwind
+define spir_kernel void @test_atomic_local(i32 addrspace(3)* %dst) #0 {
+  ; atomic_inc
+  %inc_il = tail call spir_func i32 @_Z10atomic_incPVU3AS3i(i32 addrspace(3)* %dst) #0
+  %inc_jl = tail call spir_func i32 @_Z10atomic_incPVU3AS3j(i32 addrspace(3)* %dst) #0
+  ; atomic_max
+  %max_il = tail call spir_func i32 @_Z10atomic_maxPVU3AS3ii(i32 addrspace(3)* %dst, i32 0) #0
+  %max_jl = tail call spir_func i32 @_Z10atomic_maxPVU3AS3jj(i32 addrspace(3)* %dst, i32 0) #0
+  ; atomic_min
+    %min_il = tail call spir_func i32 @_Z10atomic_minPVU3AS3ii(i32 addrspace(3)* %dst, i32 0) #0
+  %min_jl = tail call spir_func i32 @_Z10atomic_minPVU3AS3jj(i32 addrspace(3)* %dst, i32 0) #0
+  ; atomic_add
+  %add_il = tail call spir_func i32 @_Z10atomic_addPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %add_jl = tail call spir_func i32 @_Z10atomic_addPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ; atomic_sub
+  %sub_il = tail call spir_func i32 @_Z10atomic_subPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %sub_jl = tail call spir_func i32 @_Z10atomic_subPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ; atomic_or
+  %or_il = tail call spir_func i32 @_Z9atomic_orPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %or_jl = tail call spir_func i32 @_Z9atomic_orPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ; atomic_xor
+  %xor_il = tail call spir_func i32 @_Z10atomic_xorPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %xor_jl = tail call spir_func i32 @_Z10atomic_xorPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ; atomic_and
+  %and_il = tail call spir_func i32 @_Z10atomic_andPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %and_jl = tail call spir_func i32 @_Z10atomic_andPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ; atomic_cmpxchg
+  %cmpxchg_il = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS3iii(i32 addrspace(3)* %dst, i32 0, i32 1) #0
+  %cmpxchg_jl = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS3jjj(i32 addrspace(3)* %dst, i32 0, i32 1) #0
+  ; atomic_xchg
+  %xchg_il = call spir_func i32 @_Z11atomic_xchgPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
+  %xchg_jl = call spir_func i32 @_Z11atomic_xchgPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func i32 @_Z10atomic_incPVU3AS3i(i32 addrspace(3)*)
+
+declare spir_func i32 @_Z10atomic_incPVU3AS3j(i32 addrspace(3)*)
+
+declare spir_func i32 @_Z10atomic_maxPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_maxPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_minPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_minPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_addPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_addPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_subPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_subPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z9atomic_orPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z9atomic_orPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_xorPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_xorPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_andPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z10atomic_andPVU3AS3jj(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS3iii(i32 addrspace(3)*, i32, i32)
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS3jjj(i32 addrspace(3)*, i32, i32)
+
+declare spir_func i32 @_Z11atomic_xchgPVU3AS3ii(i32 addrspace(3)*, i32)
+
+declare spir_func i32 @_Z11atomic_xchgPVU3AS3jj(i32 addrspace(3)*, i32)
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.kernels = !{!0, !10}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!7}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!9}
+
+!0 = !{void (i32 addrspace(1)*)* @test_atomic_global, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_type_qual", !"volatile"}
+!5 = !{!"kernel_arg_base_type", !"int*"}
+!6 = !{!"kernel_arg_name", !"dst"}
+!7 = !{i32 1, i32 2}
+!8 = !{}
+!9 = !{!"-cl-kernel-arg-info"}
+!10 = !{void (i32 addrspace(3)*)* @test_atomic_local, !11, !2, !3, !4, !5, !6}
+!11 = !{!"kernel_arg_addr_space", i32 1}

--- a/test/SPIRV/transcoding/vector_casts.ll
+++ b/test/SPIRV/transcoding/vector_casts.ll
@@ -1,0 +1,47 @@
+; ModuleID = 'in.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; OpenCL C/C++ doesn't support vector casts. Check what convert_gentypeN built-ins
+; which translated into undecorated vector casts in SPIR-V are translated back
+; to calls to built-ins. This test doesn't cover all possible combinations of the casts;
+; there are to many of them. I hope it will be enought to catch regressions at early stage.
+
+; CHECK:      _Z13convert_uint4Dv4_f
+; CHECK-NOT:  fptoui
+
+; Function Attrs: nounwind
+define spir_kernel void @test_vector_casts(<4 x float> %in, <4 x i32> addrspace(1)* nocapture %out) #0 {
+entry:
+  %call = tail call spir_func <4 x i32> @_Z13convert_uint4Dv4_f(<4 x float> %in) #1
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %out, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func <4 x i32> @_Z13convert_uint4Dv4_f(<4 x float>) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!7}
+!opencl.compiler.options = !{!7}
+
+!0 = !{void (<4 x float>, <4 x i32> addrspace(1)*)* @test_vector_casts, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 0, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"float4", !"uint4*"}
+!4 = !{!"kernel_arg_base_type", !"float4", !"uint4*"}
+!5 = !{!"kernel_arg_type_qual", !"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{}


### PR DESCRIPTION
Fixed a couple of bugs in SPIR-V reader.
1st. Incorrect mangling of atomic_inc and atomic_min/max with unsigned arguments
2nd. Incorrect handling of vector conversions which should be converted into OCL built-ins since there is no vector conversion in OpenCL C/C++
