### PR TITLE
[SPIRV] Fix typo in include of `SPIRVSubtarget.h`

### DIFF
--- a/lib/Target/SPIRV/SPIRVTargetMachine.h
+++ b/lib/Target/SPIRV/SPIRVTargetMachine.h
@@ -38,7 +38,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVTARGETMACHINE_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVTARGETMACHINE_H
 
-#include "SPIRVSubTarget.h"
+#include "SPIRVSubtarget.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Target/TargetMachine.h"


### PR DESCRIPTION
Fix KhronosGroup/SPIRV-LLVM#23
