### PR TITLE
[SPIRV] Fix assertion due to duplicate operands in opencl version met…

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -76,10 +76,6 @@ OCLTypeToSPIRV::runOnModule(Module& Module) {
   if (std::get<0>(Src) != spv::SourceLanguageOpenCL_C)
     return false;
 
-  CLVer = std::get<1>(Src);
-  if (CLVer > kOCLVer::CL20)
-    return false;
-
   for (auto &F:Module.functions())
     adaptArgumentsByMetadata(&F);
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -250,10 +250,12 @@ WorkGroupBarrierLiterals getWorkGroupBarrierLiterals(CallInst* CI);
 size_t getAtomicBuiltinNumMemoryOrderArgs(StringRef Name);
 
 /// Get OCL version from metadata opencl.ocl.version.
+/// \param AllowMulti Allows multiple operands if true.
 /// \return OCL version encoded as Major*10^5+Minor*10^3+Rev,
 /// e.g. 201000 for OCL 2.1, 200000 for OCL 2.0, 102000 for OCL 1.2,
 /// 0 if metadata not found.
-unsigned getOCLVersion(Module *M);
+/// If there are multiple operands, check they are identical.
+unsigned getOCLVersion(Module *M, bool AllowMulti = false);
 
 /// Encode OpenCL version as Major*10^5+Minor*10^3+Rev.
 unsigned

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -710,9 +710,11 @@ std::string getMDOperandAsString(MDNode* N, unsigned I);
 /// Get metadata operand as type.
 Type* getMDOperandAsType(MDNode* N, unsigned I);
 
-/// Get a named metadata as string.
-/// Assume the named metadata has only one operand which contains one string.
-std::string getNamedMDAsString(Module *M, const std::string &MDName);
+/// Get a named metadata as a set of string.
+/// Assume the named metadata has one or more operands each of which contains
+/// one string.
+std::set<std::string> getNamedMDAsStringSet(Module *M,
+    const std::string &MDName);
 
 /// Get SPIR-V language by SPIR-V metadata spirv.Source
 std::tuple<unsigned, unsigned, std::string>

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -815,16 +815,28 @@ getMDOperandAsType(MDNode* N, unsigned I) {
   return cast<ValueAsMetadata>(N->getOperand(I))->getType();
 }
 
-std::string
-getNamedMDAsString(Module *M, const std::string &MDName) {
+std::set<std::string>
+getNamedMDAsStringSet(Module *M, const std::string &MDName) {
   NamedMDNode *NamedMD = M->getNamedMetadata(MDName);
+  std::set<std::string> StrSet;
   if (!NamedMD)
-    return "";
-  assert(NamedMD->getNumOperands() == 1 && "Invalid SPIR");
-  MDNode *MD = NamedMD->getOperand(0);
-  if (!MD || MD->getNumOperands() == 0)
-    return "";
-  return getMDOperandAsString(MD, 0);
+    return std::move(StrSet);
+
+  assert(NamedMD->getNumOperands() > 0 && "Invalid SPIR");
+
+  for (unsigned I = 0, E = NamedMD->getNumOperands(); I != E; ++I) {
+    MDNode *MD = NamedMD->getOperand(I);
+    if (!MD || MD->getNumOperands() == 0)
+      continue;
+    assert(MD->getNumOperands() == 1 && "Invalid SPIR");
+    auto S = getMDOperandAsString(MD, 0);
+    SmallVector<StringRef, 10> Exts;
+    StringRef(S).split(Exts, " ", -1, false);
+    for (auto S:Exts)
+      StrSet.insert(std::move(S.str()));
+  }
+
+  return std::move(StrSet);
 }
 
 std::tuple<unsigned, unsigned, std::string>

--- a/lib/SPIRV/TransOCLMD.cpp
+++ b/lib/SPIRV/TransOCLMD.cpp
@@ -87,7 +87,7 @@ bool
 TransOCLMD::runOnModule(Module& Module) {
   M = &Module;
   Ctx = &M->getContext();
-  CLVer = getOCLVersion(M);
+  CLVer = getOCLVersion(M, true);
   if (CLVer == 0)
     return false;
 
@@ -128,12 +128,9 @@ TransOCLMD::visit(Module *M) {
         .done();
 
   // Add extensions
-  std::string OCLExtensions = getNamedMDAsString(M, kSPIR2MD::Extensions);
-  std::string OCLOptionalCoreFeatures = getNamedMDAsString(M,
-      kSPIR2MD::OptFeatures);
-  auto S = concat(OCLOptionalCoreFeatures, OCLExtensions);
-  SmallVector<StringRef, 10> Exts;
-  StringRef(S).split(Exts, " ", -1, false);
+  auto Exts = getNamedMDAsStringSet(M, kSPIR2MD::Extensions);
+  for (auto &&I:getNamedMDAsStringSet(M, kSPIR2MD::OptFeatures))
+      Exts.insert(std::move(I));
   if (!Exts.empty()) {
     auto N = B.addNamedMD(kSPIRVMD::Extension);
     for (auto &I:Exts)

--- a/test/SPIRV/clver.ll
+++ b/test/SPIRV/clver.ll
@@ -1,0 +1,78 @@
+; Check duplicate operands in opencl.ocl.version metadata is accepted without
+; assertion.
+
+; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: FileCheck < %t %s
+
+; ModuleID = 'clver.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%struct.my_struct_t = type { i8, i32 }
+
+@var = addrspace(1) global %struct.my_struct_t { i8 97, i32 42 }, align 4
+
+; Function Attrs: nounwind
+define spir_kernel void @__OpenCL_writer_kernel(i8 zeroext %c, i32 %i) #0 {
+entry:
+  %c.addr = alloca i8, align 1
+  %i.addr = alloca i32, align 4
+  store i8 %c, i8* %c.addr, align 1, !tbaa !14
+  store i32 %i, i32* %i.addr, align 4, !tbaa !17
+  %0 = load i8* %c.addr, align 1, !tbaa !14
+  store i8 %0, i8 addrspace(1)* getelementptr inbounds (%struct.my_struct_t addrspace(1)* @var, i32 0, i32 0), align 1, !tbaa !19
+  %1 = load i32* %i.addr, align 4, !tbaa !17
+  store i32 %1, i32 addrspace(1)* getelementptr inbounds (%struct.my_struct_t addrspace(1)* @var, i32 0, i32 1), align 4, !tbaa !21
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @__OpenCL_reader_kernel(i8 addrspace(1)* %C, i32 addrspace(1)* %I) #0 {
+entry:
+  %C.addr = alloca i8 addrspace(1)*, align 8
+  %I.addr = alloca i32 addrspace(1)*, align 8
+  store i8 addrspace(1)* %C, i8 addrspace(1)** %C.addr, align 8, !tbaa !22
+  store i32 addrspace(1)* %I, i32 addrspace(1)** %I.addr, align 8, !tbaa !22
+  %0 = load i8 addrspace(1)* getelementptr inbounds (%struct.my_struct_t addrspace(1)* @var, i32 0, i32 0), align 1, !tbaa !19
+  %1 = load i8 addrspace(1)** %C.addr, align 8, !tbaa !22
+  store i8 %0, i8 addrspace(1)* %1, align 1, !tbaa !14
+  %2 = load i32 addrspace(1)* getelementptr inbounds (%struct.my_struct_t addrspace(1)* @var, i32 0, i32 1), align 4, !tbaa !21
+  %3 = load i32 addrspace(1)** %I.addr, align 8, !tbaa !22
+  store i32 %2, i32 addrspace(1)* %3, align 4, !tbaa !17
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!opencl.kernels = !{!0, !7}
+!opencl.enable.FP_CONTRACT = !{}
+!llvm.ident = !{!12, !12}
+
+; CHECK: 3 Source 3 200000
+!opencl.ocl.version = !{!13, !13}
+!opencl.spir.version = !{!13, !13}
+
+!0 = !{void (i8, i32)* @__OpenCL_writer_kernel, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 0, i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"uchar", !"uint"}
+!4 = !{!"kernel_arg_base_type", !"uchar", !"uint"}
+!5 = !{!"kernel_arg_type_qual", !"", !""}
+!6 = !{!"kernel_arg_name", !"c", !"i"}
+!7 = !{void (i8 addrspace(1)*, i32 addrspace(1)*)* @__OpenCL_reader_kernel, !8, !2, !9, !10, !5, !11}
+!8 = !{!"kernel_arg_addr_space", i32 1, i32 1}
+!9 = !{!"kernel_arg_type", !"uchar*", !"uint*"}
+!10 = !{!"kernel_arg_base_type", !"uchar*", !"uint*"}
+!11 = !{!"kernel_arg_name", !"C", !"I"}
+!12 = !{!"clang version 3.6 (tags/RELEASE_361/rc1)"}
+!13 = !{i32 2, i32 0}
+!14 = !{!15, !15, i64 0}
+!15 = !{!"omnipotent char", !16, i64 0}
+!16 = !{!"Simple C/C++ TBAA"}
+!17 = !{!18, !18, i64 0}
+!18 = !{!"int", !15, i64 0}
+!19 = !{!20, !15, i64 0}
+!20 = !{!"", !15, i64 0, !18, i64 4}
+!21 = !{!20, !18, i64 4}
+!22 = !{!23, !23, i64 0}
+!23 = !{!"any pointer", !15, i64 0}

--- a/test/SPIRV/multi_md.ll
+++ b/test/SPIRV/multi_md.ll
@@ -44,13 +44,18 @@ entry:
 
 attributes #0 = { nounwind }
 
+; CHECK-DAG: 4 Extension "cl_images"
+; CHECK-DAG: 8 Extension "cl_khr_int64_base_atomics"
+; CHECK-DAG: 9 Extension "cl_khr_int64_extended_atomics"
+; CHECK: 3 Source 3 200000
+
 !opencl.kernels = !{!0, !7}
 !opencl.enable.FP_CONTRACT = !{}
 !llvm.ident = !{!12, !12}
-
-; CHECK: 3 Source 3 200000
 !opencl.ocl.version = !{!13, !13}
 !opencl.spir.version = !{!13, !13}
+!opencl.used.extensions = !{!24, !25}
+!opencl.used.optional.core.features = !{!26, !27}
 
 !0 = !{void (i8, i32)* @__OpenCL_writer_kernel, !1, !2, !3, !4, !5, !6}
 !1 = !{!"kernel_arg_addr_space", i32 0, i32 0}
@@ -76,3 +81,7 @@ attributes #0 = { nounwind }
 !21 = !{!20, !18, i64 4}
 !22 = !{!23, !23, i64 0}
 !23 = !{!"any pointer", !15, i64 0}
+!24 = !{!"cl_khr_int64_base_atomics"}
+!25 = !{!"cl_khr_int64_base_atomics cl_khr_int64_extended_atomics"}
+!26 = !{!"cl_images"}
+!27 = !{!""}


### PR DESCRIPTION
…adata. This happens when two SPIR modules are linked together.

Remove check for OCL version in OCLTypeToSPIRV. Only check if language is C or C++.
