### PR TITLE
[SPIRV] Do not add access qualifier postfix to image type name in SPI…

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -93,6 +93,10 @@ cl::opt<bool> SPIRVGenKernelArgNameMD("spirv-gen-kernel-arg-name-md",
     cl::init(false), cl::desc("Enable generating OpenCL kernel argument name "
     "metadata"));
 
+cl::opt<bool> SPIRVGenImgTypeAccQualPostfix("spirv-gen-image-type-acc-postfix",
+    cl::init(false), cl::desc("Enable generating access qualifier postfix"
+        " in OpenCL image type names"));
+
 // Prefix for placeholder global variable name.
 const char* kPlaceholderPrefix = "placeholder.";
 
@@ -587,10 +591,12 @@ SPIRVToLLVM::transFPType(SPIRVType* T) {
 
 std::string
 SPIRVToLLVM::transOCLImageTypeName(SPIRV::SPIRVTypeImage* ST) {
-  return std::string(kSPR2TypeName::OCLPrefix)
-       + rmap<std::string>(ST->getDescriptor())
-       + kSPR2TypeName::Delimiter
-       + rmap<std::string>(ST->getAccessQualifier());
+  std::string Name = std::string(kSPR2TypeName::OCLPrefix)
+    + rmap<std::string>(ST->getDescriptor());
+  if (SPIRVGenImgTypeAccQualPostfix)
+    Name = Name + kSPR2TypeName::Delimiter
+      + rmap<std::string>(ST->getAccessQualifier());
+  return std::move(Name);
 }
 
 std::string

--- a/test/SPIRV/transcoding/OpImageQuerySize.ll
+++ b/test/SPIRV/transcoding/OpImageQuerySize.ll
@@ -13,6 +13,15 @@ target triple = "spir64-unknown-unknown"
 ; and subsequent extract or shufflevector instructions. Unfortunately there is
 ; no get_image_dim for 1D images and get_image_dim cannot replace get_image_array_size
 
+; CHECK-DAG: %opencl.image1d_t = type opaque
+; CHECK-DAG: %opencl.image1d_buffer_t = type opaque
+; CHECK-DAG: %opencl.image1d_array_t = type opaque
+; CHECK-DAG: %opencl.image2d_t = type opaque
+; CHECK-DAG: %opencl.image2d_depth_t = type opaque
+; CHECK-DAG: %opencl.image2d_array_t = type opaque
+; CHECK-DAG: %opencl.image2d_array_depth_t = type opaque
+; CHECK-DAG: %opencl.image3d_t = type opaque
+
 %opencl.image1d_t = type opaque
 %opencl.image1d_buffer_t = type opaque
 %opencl.image1d_array_t = type opaque


### PR DESCRIPTION
…R-V reader since this is incompatible with builtin libraries.

SPIR-V reader generates image type names like opencl.image2d_t.read_only. However builtin libraries compiled by SPIR producer uses image type names like opencl.image2d_t. The mismatch causes linker to insert bitcast the image functions, which can confuse certain passes in backend.

The fix is to remove the access qualifier postfix in the generated image type name in SPIR-V reader at least for now to make the name consistent.
