### PR TITLE
Fix for get_image_array_size().

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -43,6 +43,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Instruction.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
@@ -111,6 +112,10 @@ public:
   /// func(flag, order, scope) =>
   ///   __spirv_MemoryBarrier(map(scope), map(flag)|map(order))
   void transMemoryBarrier(CallInst *CI, AtomicWorkItemFenceLiterals);
+
+  /// Transform all to __spirv_Op(All|Any).  Note that the types mismatch so
+  // some extra code is emitted to convert between the two.
+  void visitCallAllAny(spv::Op OC, CallInst *CI);
 
   /// Transform atomic_* to __spirv_Atomic*.
   /// atomic_x(ptr_arg, args, order, scope) =>
@@ -328,6 +333,14 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
     visitCallNDRange(&CI, DemangledName);
     return;
   }
+  if (DemangledName == kOCLBuiltinName::All) {
+      visitCallAllAny(OpAll, &CI);
+      return;
+  }
+  if (DemangledName == kOCLBuiltinName::Any) {
+      visitCallAllAny(OpAny, &CI);
+      return;
+  }
   if (DemangledName.find(kOCLBuiltinName::AsyncWorkGroupCopy) == 0 ||
       DemangledName.find(kOCLBuiltinName::AsyncWorkGroupStridedCopy) == 0) {
     visitCallAsyncWorkGroupCopy(&CI, DemangledName);
@@ -492,6 +505,47 @@ OCL20ToSPIRV::visitCallAtomicInit(CallInst* CI) {
   ST->takeName(CI);
   CI->dropAllReferences();
   CI->eraseFromParent();
+}
+
+void
+OCL20ToSPIRV::visitCallAllAny(spv::Op OC, CallInst* CI) {
+  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
+
+  auto Args = getArguments(CI);
+  assert(Args.size() == 1);
+
+  auto *pArgTy = Args[0]->getType();
+  auto zero = ConstantInt::get(pArgTy->getScalarType(), 0);
+  auto RHS = isa<VectorType>(pArgTy) ?
+      ConstantVector::getSplat(
+        cast<VectorType>(pArgTy)->getNumElements(), zero) : zero;
+
+  auto *pCmp = CmpInst::Create(CmpInst::ICmp, CmpInst::ICMP_SLT,
+      Args[0], RHS, "cast", CI);
+
+  if (!isa<VectorType>(pArgTy))
+  {
+      auto *pCast = CastInst::CreateZExtOrBitCast(pCmp, Type::getInt32Ty(*Ctx),
+          "",
+          pCmp->getNextNode());
+      CI->replaceAllUsesWith(pCast);
+      CI->eraseFromParent();
+  }
+  else
+  {
+      mutateCallInstSPIRV(M, CI,
+      [&](CallInst *, std::vector<Value *> &Args, Type *&Ret){
+          Args[0] = pCmp;
+          Ret = Type::getInt1Ty(*Ctx);
+
+          return getSPIRVFuncName(OC);
+      },
+      [&](CallInst *CI)->Instruction * {
+          return CastInst::CreateZExtOrBitCast(CI, Type::getInt32Ty(*Ctx), "",
+              CI->getNextNode());
+      },
+      &Attrs);
+  }
 }
 
 void

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -213,6 +213,9 @@ public:
   /// Transforms OpDot instructions with a scalar type to a fmul instruction
   void visitCallDot(CallInst *CI);
   
+    void visitCallForUnaryIntAsBool(CallInst *CI, StringRef MangledName,
+      const std::string &DemangledName);
+  
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
     I.eraseFromParent();
@@ -413,6 +416,15 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
       visitCallDot(&CI);
       return;
   }
+   if (DemangledName == kOCLBuiltinName::IsFinite ||
+      DemangledName == kOCLBuiltinName::IsInf ||
+      DemangledName == kOCLBuiltinName::IsNan ||
+      DemangledName == kOCLBuiltinName::IsNormal )
+  {
+    visitCallForUnaryIntAsBool(&CI, MangledName, DemangledName);
+    return;
+  }
+  
   visitCallBuiltinSimple(&CI, MangledName, DemangledName);
 }
 
@@ -1080,6 +1092,44 @@ OCL20ToSPIRV::visitCallDot(CallInst* CI){
     CI->replaceAllUsesWith(FMulVal);
     CI->dropAllReferences();
     CI->removeFromParent();
+}
+
+void OCL20ToSPIRV::visitCallForUnaryIntAsBool(CallInst *CI, StringRef MangledName,
+  const std::string &DemangledName) {
+
+  std::vector<Type *> ArgTys;
+  std::vector<Value*> Args;
+  for (size_t I = 0, E = CI->getNumArgOperands(); I != E; ++I) {
+    ArgTys.push_back(CI->getArgOperand(I)->getType());
+    Args.push_back(CI->getArgOperand(I));
+  }
+
+  spv::Op OC = OpNop;
+  
+  if(DemangledName == kOCLBuiltinName::IsFinite) OC = OpIsFinite;
+  if(DemangledName == kOCLBuiltinName::IsInf) OC = OpIsInf;
+  if(DemangledName == kOCLBuiltinName::IsNan) OC = OpIsNan;
+  if(DemangledName == kOCLBuiltinName::IsNormal) OC = OpIsNormal;
+
+  assert( OC != OpNop && "Invalid OC in visitCallForUnaryIntAsBool");
+
+  BuiltinFuncMangleInfo mangler;
+  AttributeSet AS = CI->getCalledFunction()->getAttributes();
+
+  CallInst* CallInst = 
+    addCallInst(M, getSPIRVFuncName(OC), Type::getInt1Ty(M->getContext()), Args, 
+    &AS, 
+    CI, 
+    &mangler);
+
+  auto Ty = CI->getType();
+  auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
+  auto One = getScalarOrVectorConstantInt(Ty, 1, false);
+  auto Sel = SelectInst::Create(CallInst, One, Zero, "");
+    
+  Sel->insertAfter(CallInst);
+  CI->replaceAllUsesWith(Sel);
+  CI->eraseFromParent();
 }
 
 }

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -359,7 +359,8 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
   if (DemangledName == kOCLBuiltinName::GetImageWidth ||
       DemangledName == kOCLBuiltinName::GetImageHeight ||
       DemangledName == kOCLBuiltinName::GetImageDepth ||
-      DemangledName == kOCLBuiltinName::GetImageDim) {
+      DemangledName == kOCLBuiltinName::GetImageDim   ||
+      DemangledName == kOCLBuiltinName::GetImageArraySize) {
     visitCallGetImageSize(&CI, MangledName, DemangledName);
     return;
   }

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -210,6 +210,9 @@ public:
   void visitCallVecLoadStore(CallInst *CI, StringRef MangledName,
       const std::string &DemangledName);
 
+  /// Transforms OpDot instructions with a scalar type to a fmul instruction
+  void visitCallDot(CallInst *CI);
+  
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
     I.eraseFromParent();
@@ -404,6 +407,11 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
       DemangledName == kOCLBuiltinName::Barrier) {
     visitCallWorkGroupBarrier(&CI);
     return;
+  }
+  if (DemangledName == kOCLBuiltinName::Dot &&
+      !isa<VectorType>(CI.getOperand(0)->getType())){
+      visitCallDot(&CI);
+      return;
   }
   visitCallBuiltinSimple(&CI, MangledName, DemangledName);
 }
@@ -1063,6 +1071,15 @@ OCL20ToSPIRV::visitCallVecLoadStore(CallInst* CI,
     Ops.insert(Ops.end(), Consts.begin(), Consts.end());
   };
   transBuiltin(CI, Info);
+}
+
+void
+OCL20ToSPIRV::visitCallDot(CallInst* CI){
+    IRBuilder<> Builder(CI);
+    Value *FMulVal = Builder.CreateFMul(CI->getOperand(0), CI->getOperand(1));
+    CI->replaceAllUsesWith(FMulVal);
+    CI->dropAllReferences();
+    CI->removeFromParent();
 }
 
 }

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -856,16 +856,16 @@ OCL20ToSPIRV::visitCallGetImageSize(CallInst* CI,
       assert(IsImg);
       Desc = map<SPIRVTypeImageDescriptor>(TyName.str());
       Dim = getImageDimension(Desc.Dim) + Desc.Arrayed;
-      Ret = CI->getCalledFunction()->getReturnType();
+      Ret = CI->getType()->isIntegerTy(64) ?
+          Type::getInt64Ty(*Ctx) :
+          Type::getInt32Ty(*Ctx);
       if (Dim > 1)
         Ret = VectorType::get(Ret, Dim);
       if (Desc.Dim == DimBuffer)
-          return getSPIRVFuncName(OpImageQuerySize,
-              kSPIRVPostfix::Divider + getPostfixForReturnType(CI, false));
+          return getSPIRVFuncName(OpImageQuerySize, CI->getType());
       else {
         Args.push_back(getInt32(M, 0));
-        return getSPIRVFuncName(OpImageQuerySizeLod,
-            kSPIRVPostfix::Divider + getPostfixForReturnType(CI, false));
+        return getSPIRVFuncName(OpImageQuerySizeLod, CI->getType());
       }
     },
     [&](CallInst *NCI)->Instruction * {

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -97,7 +97,20 @@ getExtOp(StringRef OrigName, const std::string &GivenDemangledName) {
   OCLExtOpKind EOC;
   bool Found = OCLExtOpMap::rfind(DemangledName, &EOC);
   if (!Found) {
-    std::string Prefix = isLastFuncParamSigned(OrigName) ? "s_" : "u_";
+    std::string Prefix;
+    switch (LastFuncParamType(OrigName))
+    {
+    case ParamType::UNSIGNED:
+        Prefix = "u_";
+        break;
+    case ParamType::SIGNED:
+        Prefix = "s_";
+        break;
+    case ParamType::FLOAT:
+        Prefix = "f";
+        break;
+    default: assert(0 && "unknown mangling!");
+    }
     Found = OCLExtOpMap::rfind(Prefix + DemangledName, &EOC);
   }
   if (Found)

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -143,6 +143,7 @@ namespace kOCLBuiltinName {
   const static char AtomicWorkItemFence[] = "atomic_work_item_fence";
   const static char Barrier[]            = "barrier";
   const static char ConvertPrefix[]      = "convert_";
+  const static char Dot[]                = "dot";
   const static char EnqueueKernel[]      = "enqueue_kernel";
   const static char GetFence[]           = "get_fence";
   const static char GetImageArraySize[]  = "get_image_array_size";

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -154,6 +154,7 @@ namespace kOCLBuiltinName {
   const static char MemFence[]           = "mem_fence";
   const static char NDRangePrefix[]      = "ndrange_";
   const static char Pipe[]               = "pipe";
+  const static char Prefetch[]           = "prefetch";
   const static char ReadImage[]          = "read_image";
   const static char ReadPipe[]           = "read_pipe";
   const static char RoundingPrefix[]     = "_r";

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -175,6 +175,10 @@ namespace kOCLBuiltinName {
   const static char WritePipe[]          = "write_pipe";
   const static char WorkGroupPrefix[]    = "work_group_";
   const static char WorkPrefix[]         = "work_";
+  const static char IsFinite[]           = "isfinite";
+  const static char IsNan[]              = "isnan";
+  const static char IsNormal[]           = "isnormal";
+  const static char IsInf[]              = "isinf";
 }
 
 /// OCL 1.x atomic memory order when translated to 2.0 atomics.

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -132,6 +132,8 @@ struct OCLBuiltinTransInfo {
 //
 ///////////////////////////////////////////////////////////////////////////////
 namespace kOCLBuiltinName {
+  const static char All[]                       = "all";
+  const static char Any[]                       = "any";
   const static char AsyncWorkGroupCopy[]        = "async_work_group_copy";
   const static char AsyncWorkGroupStridedCopy[] = "async_work_group_strided_copy";
   const static char AtomPrefix[]         = "atom_";

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -765,9 +765,27 @@ eraseIfNoUse(Value *V);
 bool
 isMangledTypeUnsigned(char Mangled);
 
+// Check if a mangled type name is signed
+bool
+isMangledTypeSigned(char Mangled);
+
+// Check if a mangled type name is floating point
+bool
+isMangledTypeFP(char Mangled);
+
 // Check if \param I is valid vector size: 2, 3, 4, 8, 16.
 bool
 isValidVectorSize(unsigned I);
+
+enum class ParamType
+{
+    FLOAT    = 0,
+    SIGNED   = 1,
+    UNSIGNED = 2,
+    UNKNOWN  = 3
+};
+
+ParamType LastFuncParamType(const std::string& MangledName);
 
 // Check if the last function parameter is signed
 bool

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -478,7 +478,7 @@ void addFnAttr(LLVMContext *Context, CallInst *Call,
     Attribute::AttrKind Attr);
 void saveLLVMModule(Module *M, const std::string &OutputFile);
 std::string mapSPIRVTypeToOCLType(SPIRVType* Ty, bool Signed);
-std::string mapLLVMTypeToOCLType(Type* Ty, bool Signed);
+std::string mapLLVMTypeToOCLType(const Type* Ty, bool Signed);
 SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target);
 
 /// Add decorations to a SPIR-V entry.
@@ -539,6 +539,8 @@ bool isDecoratedSPIRVFunc(const Function *F, std::string *UndecName = nullptr);
 
 /// Get a canonical function name for a SPIR-V op code.
 std::string getSPIRVFuncName(Op OC, StringRef PostFix = "");
+
+std::string getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned = false);
 
 /// Get a canonical function name for a SPIR-V extended instruction
 std::string getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
@@ -723,6 +725,7 @@ std::string getPostfix(Decoration Dec, unsigned Value = 0);
 /// Get postfix _R{ReturnType} for return type
 /// The returned postfix does not includ "_" at the beginning
 std::string getPostfixForReturnType(CallInst *CI, bool IsSigned = false);
+std::string getPostfixForReturnType(const Type *pRetTy, bool IsSigned = false);
 
 Constant *
 getScalarOrVectorConstantInt(Type *T, uint64_t V, bool isSigned = false);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -926,6 +926,8 @@ transTypeDesc(Type *Ty, const BuiltinArgTypeMangleInfo &Info) {
   }
   if(auto *IntTy = dyn_cast<IntegerType>(Ty)) {
     switch(IntTy->getBitWidth()) {
+    case 1:
+      return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_BOOL));
     case 8:
       return SPIR::RefParamType(new SPIR::PrimitiveType(Signed?
           SPIR::PRIMITIVE_CHAR:SPIR::PRIMITIVE_UCHAR));

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -503,6 +503,23 @@ isMangledTypeUnsigned(char Mangled) {
       || Mangled == 'm' /* ulong */;
 }
 
+// Check if a mangled type name is signed
+bool
+isMangledTypeSigned(char Mangled) {
+  return Mangled == 'c' /* char */
+      || Mangled == 'a' /* signed char */
+      || Mangled == 's' /* short */
+      || Mangled == 'i' /* int */
+      || Mangled == 'l' /* long */;
+}
+
+// Check if a mangled type name is floating point
+bool
+isMangledTypeFP(char Mangled) {
+  return Mangled == 'f' /* float */
+      || Mangled == 'd'; /* double */
+}
+
 void
 eraseSubstitutionFromMangledName(std::string& MangledName) {
   auto Len = MangledName.length();
@@ -512,16 +529,32 @@ eraseSubstitutionFromMangledName(std::string& MangledName) {
   }
 }
 
-// Check if the last argument is signed
-bool
-isLastFuncParamSigned(const std::string& MangledName) {
+ParamType LastFuncParamType(const std::string& MangledName)
+{
   auto Copy = MangledName;
   eraseSubstitutionFromMangledName(Copy);
   char Mangled = Copy.back();
-  bool Signed = true;
+
   if (isMangledTypeUnsigned(Mangled))
-    Signed = false;
-  return Signed;
+  {
+      return ParamType::UNSIGNED;
+  }
+  else if (isMangledTypeSigned(Mangled))
+  {
+      return ParamType::SIGNED;
+  }
+  else if (isMangledTypeFP(Mangled))
+  {
+      return ParamType::FLOAT;
+  }
+
+  return ParamType::UNKNOWN;
+}
+
+// Check if the last argument is signed
+bool
+isLastFuncParamSigned(const std::string& MangledName) {
+  return LastFuncParamType(MangledName) == ParamType::SIGNED;
 }
 
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -110,14 +110,14 @@ saveLLVMModule(Module *M, const std::string &OutputFile) {
 }
 
 std::string
-mapLLVMTypeToOCLType(Type* Ty, bool Signed) {
+mapLLVMTypeToOCLType(const Type* Ty, bool Signed) {
   if (Ty->isHalfTy())
     return "half";
   if (Ty->isFloatTy())
     return "float";
   if (Ty->isDoubleTy())
     return "double";
-  if (IntegerType* intTy = dyn_cast<IntegerType>(Ty)) {
+  if (auto* intTy = dyn_cast<IntegerType>(Ty)) {
     std::string SignPrefix;
     std::string Stem;
     if (!Signed)
@@ -141,7 +141,7 @@ mapLLVMTypeToOCLType(Type* Ty, bool Signed) {
     }
     return SignPrefix + Stem;
   }
-  if (VectorType* vecTy = dyn_cast<VectorType>(Ty)) {
+  if (auto* vecTy = dyn_cast<VectorType>(Ty)) {
     Type* eleTy = vecTy->getElementType();
     unsigned size = vecTy->getVectorNumElements();
     std::stringstream ss;
@@ -363,6 +363,11 @@ getSPIRVFuncName(Op OC, StringRef PostFix) {
 }
 
 std::string
+getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned) {
+  return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider + getPostfixForReturnType(pRetTy, false));
+}
+
+std::string
 getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
     StringRef PostFix) {
   std::string ExtOpName;
@@ -414,8 +419,13 @@ getPostfix(Decoration Dec, unsigned Value) {
 
 std::string
 getPostfixForReturnType(CallInst *CI, bool IsSigned) {
+    return getPostfixForReturnType(CI->getType(), IsSigned);
+}
+
+std::string
+getPostfixForReturnType(const Type *pRetTy, bool IsSigned) {
   return std::string(kSPIRVPostfix::Return) +
-        mapLLVMTypeToOCLType(CI->getType(), IsSigned);
+        mapLLVMTypeToOCLType(pRetTy, IsSigned);
 }
 
 Op

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -364,7 +364,8 @@ getSPIRVFuncName(Op OC, StringRef PostFix) {
 
 std::string
 getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned) {
-  return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider + getPostfixForReturnType(pRetTy, false));
+  return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider
+      + getPostfixForReturnType(pRetTy, false));
 }
 
 std::string

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1430,8 +1430,28 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
       auto Cmp = BM->addCmpInst(OC, BBT,
         transValue(CI->getArgOperand(0), BB),
         transValue(CI->getArgOperand(1), BB), BB);
-      auto CastOC = IsVector ? OpSConvert : OpUConvert;
-      return BM->addUnaryInst(CastOC, BT, Cmp, BB);
+      SPIRVValue *pZero = nullptr;
+      SPIRVValue *pOne  = nullptr;
+      if (IsVector)
+      {
+          std::vector<SPIRVValue*> BVZero;
+          std::vector<SPIRVValue*> BVOne;
+          for (auto i = 0U; i < ResultTy->getVectorNumElements(); i++)
+          {
+              BVZero.push_back(transValue(
+                  ConstantInt::get(ResultTy->getScalarType(), 0), nullptr));
+              BVOne.push_back(transValue(
+                  ConstantInt::get(ResultTy->getScalarType(), ~0), nullptr));
+          }
+          pZero = BM->addCompositeConstant(BT, BVZero);
+          pOne  = BM->addCompositeConstant(BT, BVOne);
+      }
+      else
+      {
+          pZero = BM->addIntegerConstant(static_cast<SPIRVTypeInt*>(BT), 0);
+          pOne  = BM->addIntegerConstant(static_cast<SPIRVTypeInt*>(BT), 1);
+      }
+      return BM->addSelectInst(Cmp, pOne, pZero, BB);
     } else if (isBinaryOpCode(OC)) {
       assert(CI && CI->getNumArgOperands() == 2 && "Invalid call inst");
       return BM->addBinaryInst(OC, transType(CI->getType()),

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1510,10 +1510,10 @@ addPassesForSPIRV(PassManager &PassMgr) {
   PassMgr.add(createTransOCLMD());
   PassMgr.add(createOCL21ToSPIRV());
   PassMgr.add(createSPIRVLowerOCLBlocks());
-  PassMgr.add(createSPIRVLowerBool());
   PassMgr.add(createOCL20ToSPIRV());
   PassMgr.add(createSPIRVRegularizeLLVM());
   PassMgr.add(createSPIRVLowerConstExpr());
+  PassMgr.add(createSPIRVLowerBool());
 }
 
 bool

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -365,6 +365,7 @@ SPIRVModuleImpl::addLine(SPIRVEntry* E, SPIRVString* FileName,
 // multiple targets.
 void
 SPIRVModuleImpl::optimizeDecorates() {
+
   SPIRVDBG(spvdbgs() << "[optimizeDecorates] begin\n");
   for (auto I = DecorateSet.begin(), E = DecorateSet.end(); I != E;) {
     auto D = *I;
@@ -398,11 +399,17 @@ SPIRVModuleImpl::optimizeDecorates() {
         continue;
       Targets.push_back(E->getTargetId());
     }
-    DecorateSet.erase(ER.first, ER.second);
-    auto GD = new SPIRVGroupDecorate(G, Targets);
-    DecGroupVec.push_back(G);
-    GroupDecVec.push_back(GD);
+
+    // WordCount is only 16 bits.  We can only have 65535 - FixedWC targtets per group.
+    // For now, just skip using a group if the number of targets to too big
+    if( Targets.size() < 65530 ) {
+      DecorateSet.erase(ER.first, ER.second);
+      auto GD = new SPIRVGroupDecorate(G, Targets);
+      DecGroupVec.push_back(G);
+      GroupDecVec.push_back(GD);
+    }
   }
+
 }
 
 SPIRVValue*


### PR DESCRIPTION
processing for get_image_array_size() was falling into the ExtInst case and yielding:

error: 233: Invalid extended instruction number: 138

From the disassembler.

Also, since it returns a size_t, I had to add the return type to the name since, for example, in 64-bit you could have i32 get_image_width() => OpImageQuerySizeLod and i64 get_image_array_size() => OpImageQuerySizeLod which were conflicting.
