### PR TITLE
Implement support of OpAtomicCompareExchange in SPIR-V generator and …

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -127,11 +127,16 @@ public:
   ///   __spirv_MemoryBarrier(map(scope), map(flag)|map(order))
   void visitCallAtomicWorkItemFence(CallInst *CI);
 
-  /// Transform atom_cmpxchg/atomic_cmpxchg to atomic_compare_exchange.
-  /// In atom_cmpxchg/atomic_cmpxchg, the expected value parameter is a value.
-  /// However in atomic_compare_exchange it is a pointer. The transformation
-  /// adds an alloca instruction, store the expected value in the pointer, and
-  /// pass the pointer as argument.
+  /// Transform atomic_compare_exchange call.
+  /// In atomic_compare_exchange, the expected value parameter is a pointer.
+  /// However in SPIR-V it is a value. The transformation adds a load 
+  /// instruction, result of which is passed to atomic_compare_exchange as
+  /// argument.
+  /// The transformation adds a store instruction after the call, to update the
+  /// value in expected with the value pointed to by object. Though, it is not
+  /// necessary in case they are equal, this approach makes result code simpler.
+  /// Also ICmp instruction is added, because the call must return result of
+  /// comparison.
   /// \returns the call instruction of atomic_compare_exchange_strong.
   CallInst *visitCallAtomicCmpXchg(CallInst *CI,
       const std::string &DemangledName);
@@ -364,8 +369,9 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
       visitCallAtomicWorkItemFence(PCI);
       return;
     }
-    if (DemangledName == kOCLBuiltinName::AtomCmpXchg ||
-        DemangledName == kOCLBuiltinName::AtomicCmpXchg) {
+    if (DemangledName == kOCLBuiltinName::AtomicCmpXchgStrong ||
+        DemangledName == kOCLBuiltinName::AtomicCmpXchgWeak) {
+      assert(CLVer == kOCLVer::CL20 && "Wrong version of OpenCL");
       PCI = visitCallAtomicCmpXchg(PCI, DemangledName);
     }
     visitCallAtomicLegacy(PCI, MangledName, DemangledName);
@@ -503,21 +509,24 @@ CallInst *
 OCL20ToSPIRV::visitCallAtomicCmpXchg(CallInst* CI,
     const std::string& DemangledName) {
   AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-  Value *Alloca = nullptr;
+  Value *Expected = nullptr;
   CallInst *NewCI = nullptr;
-  mutateCallInstOCL(M, CI, [&](CallInst *, std::vector<Value *> &Args,
+  mutateCallInstOCL(M, CI, [&](CallInst * CI, std::vector<Value *> &Args,
       Type *&RetTy){
-    auto &CmpVal = Args[1];
-    Alloca = new AllocaInst(CmpVal->getType(), "",
-        CI->getParent()->getParent()->getEntryBlock().getFirstInsertionPt());
-    auto Store = new StoreInst(CmpVal, Alloca, CI);
-    CmpVal = Alloca;
-    RetTy = Type::getInt1Ty(*Ctx);
+    Expected = Args[1]; // temporary save second argument.
+    Args[1] = new LoadInst(Args[1], "exp", false, CI);
+    RetTy = Args[2]->getType();
+    assert(Args[0]->getType()->getPointerElementType()->isIntegerTy() &&
+      Args[1]->getType()->isIntegerTy() && Args[2]->getType()->isIntegerTy() &&
+      "In SPIR-V 1.0 arguments of OpAtomicCompareExchange must be "
+      "an integer type scalars");
     return kOCLBuiltinName::AtomicCmpXchgStrong;
   },
   [&](CallInst *NCI)->Instruction * {
     NewCI = NCI;
-    return new LoadInst(Alloca, "", false, NCI->getNextNode());
+    Instruction* Store = new StoreInst(NCI, Expected, NCI->getNextNode());
+    return new ICmpInst(Store->getNextNode(), CmpInst::ICMP_EQ, NCI,
+                        NCI->getArgOperand(1));
   },
   &Attrs);
   return NewCI;
@@ -640,10 +649,10 @@ OCL20ToSPIRV::visitCallAtomicLegacy(CallInst* CI,
   OCLBuiltinTransInfo Info;
   Info.UniqName = "atomic_" + Prefix + Sign + Stem.str() + Postfix;
   std::vector<int> PostOps;
+  PostOps.push_back(OCLLegacyAtomicMemScope);
   PostOps.push_back(OCLLegacyAtomicMemOrder);
   if (Stem.startswith("compare_exchange"))
     PostOps.push_back(OCLLegacyAtomicMemOrder);
-  PostOps.push_back(OCLLegacyAtomicMemScope);
 
   Info.PostProc = [=](std::vector<Value *> &Ops){
     for (auto &I:PostOps){
@@ -677,10 +686,10 @@ OCL20ToSPIRV::visitCallAtomicCpp11(CallInst* CI,
 
     if (!Stem.endswith("_explicit")) {
       NewStem = NewStem + "_explicit";
+      PostOps.push_back(OCLMS_device);
       PostOps.push_back(OCLMO_seq_cst);
       if (Stem.startswith("compare_exchange"))
         PostOps.push_back(OCLMO_seq_cst);
-      PostOps.push_back(OCLMS_device);
     } else {
       auto MaxOps = getOCLCpp11AtomicMaxNumOps(
           Stem.drop_back(strlen("_explicit")));
@@ -707,11 +716,12 @@ void
 OCL20ToSPIRV::transAtomicBuiltin(CallInst* CI,
     OCLBuiltinTransInfo& Info) {
   AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstSPIRV(M, CI, [=](CallInst *, std::vector<Value *> &Args){
+  mutateCallInstSPIRV(M, CI, [=](CallInst * CI, std::vector<Value *> &Args){
     Info.PostProc(Args);
-    auto NumOrder = getAtomicBuiltinNumMemoryOrderArgs(Info.UniqName);
-    auto ScopeIdx = Args.size() - 1;
-    auto OrderIdx = Args.size() - NumOrder - 1;
+    const size_t NumOrder = getAtomicBuiltinNumMemoryOrderArgs(Info.UniqName);
+    const size_t ArgsCount = Args.size();
+    const size_t ScopeIdx = ArgsCount - NumOrder - 1;
+    const size_t OrderIdx = ArgsCount - NumOrder;
     Args[ScopeIdx] = mapUInt(M, cast<ConstantInt>(Args[ScopeIdx]),
         [](unsigned I){
       return map<Scope>(static_cast<OCLScopeKind>(I));
@@ -721,7 +731,10 @@ OCL20ToSPIRV::transAtomicBuiltin(CallInst* CI,
           [](unsigned Ord) {
       return mapOCLMemSemanticToSPIRV(0, static_cast<OCLMemOrderKind>(Ord));
     });
-    move(Args, OrderIdx, Args.size(), findFirstPtr(Args) + 1);
+    move(Args, ScopeIdx, ArgsCount, findFirstPtr(Args) + 1);
+    if(Info.UniqName.find("atomic_compare_exchange") != std::string::npos) {
+      std::swap(Args[ArgsCount-1], Args[ArgsCount-2]);
+    }
     return getSPIRVFuncName(OCLSPIRVBuiltinMap::map(Info.UniqName));
   }, &Attrs);
 }

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -142,8 +142,6 @@ OCL21ToSPIRV::visitCallInst(CallInst& CI) {
     return;
   DEBUG(dbgs() << "DemangledName:" << DemangledName << '\n');
   StringRef Ref(DemangledName);
-  assert(Ref.startswith("Op") && "Invalid builtin name");
-  Ref = Ref.drop_front(2);
 
   Op OC = OpNop;
   if (!OpCodeNameMap::rfind(Ref.str(), &OC))

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -103,7 +103,7 @@ AtomicWorkItemFenceLiterals getAtomicWorkItemFenceLiterals(CallInst* CI) {
 }
 
 size_t getAtomicBuiltinNumMemoryOrderArgs(StringRef Name) {
-  if (Name.find("compare_exchange_strong") != StringRef::npos)
+  if (Name.startswith("atomic_compare_exchange"))
     return 2;
   return 1;
 }

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -141,7 +141,8 @@ namespace kOCLBuiltinName {
   const static char AtomicPrefix[]       = "atomic_";
   const static char AtomicCmpXchg[]      = "atomic_cmpxchg";
   const static char AtomicCmpXchgStrong[] = "atomic_compare_exchange_strong";
-  const static char AtomicInit[]         = "atomic_init";
+  const static char AtomicCmpXchgWeak[]   = "atomic_compare_exchange_weak";
+  const static char AtomicInit[]          = "atomic_init";
   const static char AtomicWorkItemFence[] = "atomic_work_item_fence";
   const static char Barrier[]            = "barrier";
   const static char ConvertPrefix[]      = "convert_";

--- a/test/SPIRV/AtomicCompareExchange_cl12.ll
+++ b/test/SPIRV/AtomicCompareExchange_cl12.ll
@@ -1,0 +1,55 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: 3 Source 3 102000
+
+; CHECK: Name [[Pointer:[0-9]+]] "object"
+; CHECK: Name [[Comparator:[0-9]+]] "expected"
+; CHECK: Name [[Value:[0-9]+]] "desired"
+; CHECK: 4 TypeInt [[int:[0-9]+]] 32 0
+; CHECK: 4 TypePointer [[int_ptr:[0-9]+]] 5 [[int]]
+; CHECK: Constant [[int]] [[DeviceScope:[0-9]+]] 1
+; CHECK: Constant [[int]] [[SequentiallyConsistent_MS:[0-9]+]] 16
+
+; Function Attrs: nounwind
+define spir_func i32 @test(i32 addrspace(1)* %object, i32 %expected, i32 %desired) #0 {
+; CHECK: FunctionParameter [[int_ptr]] [[Pointer]]
+; CHECK: FunctionParameter [[int]] [[Comparator]]
+; CHECK: FunctionParameter [[int]] [[Value]]
+entry:
+  %object.addr = alloca i32 addrspace(1)*, align 4
+  %expected.addr = alloca i32, align 4
+  %desired.addr = alloca i32, align 4
+  %res = alloca i32, align 4
+  store i32 addrspace(1)* %object, i32 addrspace(1)** %object.addr, align 4
+  store i32 %expected, i32* %expected.addr, align 4
+  store i32 %desired, i32* %desired.addr, align 4
+  %0 = load i32 addrspace(1)** %object.addr, align 4
+  %1 = load i32* %expected.addr, align 4
+  %2 = load i32* %desired.addr, align 4
+
+  %call = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)* %0, i32 %1, i32 %2)
+; CHECK 9 AtomicCompareExchange [[int]] [[result:[0-9]+]] [[Pointer]] [[DeviceScope]] [[SequentiallyConsistent_MS]] [[SequentiallyConsistent_MS]] [[Value]] [[Comparator]]
+
+  store i32 %call, i32* %res, align 4
+  %3 = load i32* %res, align 4
+  ret i32 %3
+; CHECK 2 ReturnValue [[result]]
+}
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)*, i32, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!0}
+!opencl.used.extensions = !{!1}
+!opencl.used.optional.core.features = !{!1}
+!opencl.compiler.options = !{!1}
+
+!0 = !{i32 1, i32 2}
+!1 = !{}

--- a/test/SPIRV/AtomicCompareExchange_cl20.ll
+++ b/test/SPIRV/AtomicCompareExchange_cl20.ll
@@ -1,0 +1,89 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: 3 Source 3 200000
+
+; CHECK: Name [[Pointer:[0-9]+]] "object"
+; CHECK: Name [[ComparatorPtr:[0-9]+]] "expected"
+; CHECK: Name [[Value:[0-9]+]] "desired"
+; CHECK: 4 TypeInt [[int:[0-9]+]] 32 0
+; CHECK: 4 TypePointer [[int_ptr:[0-9]+]] 8 [[int]]
+; CHECK: 2 TypeBool [[bool:[0-9]+]]
+; CHECK: Constant [[int]] [[DeviceScope:[0-9]+]] 1
+; CHECK: Constant [[int]] [[SequentiallyConsistent_MS:[0-9]+]] 16
+
+; Function Attrs: nounwind
+define spir_func void @test(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
+; CHECK: FunctionParameter [[int_ptr]] [[Pointer]]
+; CHECK: FunctionParameter [[int_ptr]] [[ComparatorPtr]]
+; CHECK: FunctionParameter [[int]] [[Value]]
+
+entry:
+  %object.addr = alloca i32 addrspace(4)*, align 4
+  %expected.addr = alloca i32 addrspace(4)*, align 4
+  %desired.addr = alloca i32, align 4
+  %strong_res = alloca i8, align 1
+  %res = alloca i8, align 1
+  %weak_res = alloca i8, align 1
+  store i32 addrspace(4)* %object, i32 addrspace(4)** %object.addr, align 4
+  store i32 addrspace(4)* %expected, i32 addrspace(4)** %expected.addr, align 4
+  store i32 %desired, i32* %desired.addr, align 4
+  %0 = load i32 addrspace(4)** %object.addr, align 4
+  %1 = load i32 addrspace(4)** %expected.addr, align 4
+  %2 = load i32* %desired.addr, align 4
+
+  %call = call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %2)
+; CHECK: Load [[int]] [[Comparator:[0-9]+]] [[ComparatorPtr]]
+; CHECK-NEXT: 9 AtomicCompareExchange [[int]] [[Result:[0-9]+]] [[Pointer]] [[DeviceScope]] [[SequentiallyConsistent_MS]] [[SequentiallyConsistent_MS]] [[Value]] [[Comparator]]
+; CHECK-NEXT: Store [[ComparatorPtr]] [[Result]]
+; CHECK-NEXT: IEqual [[bool]] [[CallRes:[0-9]+]] [[Result]] [[Comparator]]
+; CHECK-NOT: [[Result]]
+  %frombool = zext i1 %call to i8
+  store i8 %frombool, i8* %strong_res, align 1
+  %3 = load i8* %strong_res, align 1
+  %tobool = trunc i8 %3 to i1
+  %lnot = xor i1 %tobool, true
+  %frombool1 = zext i1 %lnot to i8
+  store i8 %frombool1, i8* %res, align 1
+  %4 = load i32 addrspace(4)** %object.addr, align 4
+  %5 = load i32 addrspace(4)** %expected.addr, align 4
+  %6 = load i32* %desired.addr, align 4
+
+  %call2 = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %4, i32 addrspace(4)* %5, i32 %6)
+; CHECK: Load [[int]] [[ComparatorWeak:[0-9]+]] [[ComparatorPtr]]
+; CHECK-NEXT: 9 AtomicCompareExchangeWeak [[int]] [[Result:[0-9]+]] [[Pointer]] [[DeviceScope]] [[SequentiallyConsistent_MS]] [[SequentiallyConsistent_MS]] [[Value]] [[ComparatorWeak]]
+; CHECK-NEXT: Store [[ComparatorPtr]] [[Result]]
+; CHECK-NEXT: IEqual [[bool]] [[CallRes:[0-9]+]] [[Result]] [[ComparatorWeak]]
+; CHECK-NOT: [[Result]]
+
+  %frombool3 = zext i1 %call2 to i8
+  store i8 %frombool3, i8* %weak_res, align 1
+  %7 = load i8* %weak_res, align 1
+  %tobool4 = trunc i8 %7 to i1
+  %lnot5 = xor i1 %tobool4, true
+  %frombool6 = zext i1 %lnot5 to i8
+  store i8 %frombool6, i8* %res, align 1
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+
+declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 2, i32 0}
+!2 = !{}

--- a/test/SPIRV/transcoding/AtomicCompareExchange_cl12.ll
+++ b/test/SPIRV/transcoding/AtomicCompareExchange_cl12.ll
@@ -1,0 +1,40 @@
+; ModuleID = 'AtomicCompareExchange_cl12.cl'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; Check conversion of atomic_cmpxchng to atomic_compare_exchange_strong.
+
+; Function Attrs: nounwind
+
+; CHECK:         define spir_func i32 @test
+; CHECK-LABEL:   entry
+; CHECK:         [[PTR:%expected[0-9]*]] = alloca i32, align 4
+; CHECK:         store i32 {{.*}}, i32* [[PTR]]
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}%object, i32* [[PTR]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK-NEXT;         load i32* [[PTR]]
+define spir_func i32 @test(i32 addrspace(1)* %object, i32 %expected, i32 %desired) #0 {
+entry:
+  %call = tail call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)* %object, i32 %expected, i32 %desired) #2
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)*, i32, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!0}
+!opencl.used.extensions = !{!1}
+!opencl.used.optional.core.features = !{!1}
+!opencl.compiler.options = !{!1}
+
+!0 = !{i32 1, i32 2}
+!1 = !{}

--- a/test/SPIRV/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/SPIRV/transcoding/AtomicCompareExchange_cl20.ll
@@ -1,0 +1,51 @@
+; ModuleID = '/tmp/aelizuno/AtomicCompareExchange_cl20.ll'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_compare_exchange_strong and atomic_compare_exchange_weak.
+
+; Function Attrs: nounwind
+
+; CHECK:         define spir_func void @test
+; CHECK-LABEL:   entry
+; CHECK:         [[PTR_STRONG:%expected[0-9]*]] = alloca i32, align 4
+; CHECK:         store i32 {{.*}}, i32* [[PTR_STRONG]]
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* %object, i32* [[PTR_STRONG]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK:         load i32* [[PTR_STRONG]]
+
+; CHECK:         [[PTR_WEAK:%expected[0-9]*]] = alloca i32, align 4
+; CHECK:         store i32 {{.*}}, i32* [[PTR_WEAK]]
+; CHECK:         call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPiiiii{{.*}}(i32 {{.*}}* %object, i32* [[PTR_WEAK]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK:         load i32* [[PTR_WEAK]]
+
+; Function Attrs: nounwind
+define spir_func void @test(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
+entry:
+  %call = tail call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #2
+  %call2 = tail call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #2
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+
+declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 2, i32 0}
+!2 = !{}


### PR DESCRIPTION
…consumer

Type of return value, arguments' types and thier order is corrected.
