### PR TITLE
[SPIR-V] Fix encoding of OpImageSampleExplicitLod instruction.

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -685,6 +685,9 @@ ConstantInt *getUInt32(Module *M, unsigned value);
 /// Get a 16 bit unsigned integer constant.
 ConstantInt *getUInt16(Module *M, unsigned short value);
 
+// Get a 32 bit floating point constant.
+Constant *getFloat32(Module *M, float value);
+
 /// Get a 32 bit integer constant vector.
 std::vector<Value *> getInt32(Module *M, const std::vector<int> &value);
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -342,7 +342,7 @@ public:
   /// =>
   ///   read_image(image, sampler, ...)
   /// \return transformed call instruction.
-  CallInst *postProcessOCLReadImage(SPIRVInstruction *BI, CallInst *CI,
+  Instruction *postProcessOCLReadImage(SPIRVInstruction *BI, CallInst *CI,
       const std::string &DemangledName);
 
   /// \brief Post-process OpBuildNDRange.
@@ -1040,29 +1040,50 @@ SPIRVToLLVM::postProcessOCLBuiltinWithArrayArguments(Function* F,
 }
 
 // ToDo: Handle unsigned integer return type. May need spec change.
-CallInst *
+Instruction *
 SPIRVToLLVM::postProcessOCLReadImage(SPIRVInstruction *BI, CallInst* CI,
     const std::string &FuncName) {
   AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(M, CI, [=](CallInst *, std::vector<Value *> &Args){
-    CallInst *CallSampledImg = cast<CallInst>(Args[0]);
-    auto Img = CallSampledImg->getArgOperand(0);
-    assert(isOCLImageType(Img->getType()));
-    auto Sampler = CallSampledImg->getArgOperand(1);
-    Args[0] = Img;
-    Args.insert(Args.begin() + 1, Sampler);
-    if (CallSampledImg->hasOneUse()) {
-      CallSampledImg->replaceAllUsesWith(
-          UndefValue::get(CallSampledImg->getType()));
-      CallSampledImg->dropAllReferences();
-      CallSampledImg->eraseFromParent();
-    }
-    Type *T = CI->getType();
-    if (auto VT = dyn_cast<VectorType>(T))
-      T = VT->getElementType();
-    return std::string(kOCLBuiltinName::SampledReadImage)
-      + (T->isFloatingPointTy()?'f':'i');
-  }, &Attrs);
+  StringRef ImageTypeName;
+  bool isDepthImage = false;
+  if (isOCLImageType(
+          (cast<CallInst>(CI->getOperand(0)))->getArgOperand(0)->getType(),
+          &ImageTypeName))
+    isDepthImage = ImageTypeName.endswith("depth_t");
+  return mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args, llvm::Type *&RetTy) {
+        CallInst *CallSampledImg = cast<CallInst>(Args[0]);
+        auto Img = CallSampledImg->getArgOperand(0);
+        assert(isOCLImageType(Img->getType()));
+        auto Sampler = CallSampledImg->getArgOperand(1);
+        Args[0] = Img;
+        Args.insert(Args.begin() + 1, Sampler);
+        // Drop "Image Operadns" arguments - they are not used by OpenCL at the
+        // moment.
+        // TODO: OpenCL extension mipmap images will use LOD image operand.
+        Args.erase(Args.begin() + 3, Args.end());
+        if (CallSampledImg->hasOneUse()) {
+          CallSampledImg->replaceAllUsesWith(
+              UndefValue::get(CallSampledImg->getType()));
+          CallSampledImg->dropAllReferences();
+          CallSampledImg->eraseFromParent();
+        }
+        Type *T = CI->getType();
+        if (auto VT = dyn_cast<VectorType>(T))
+          T = VT->getElementType();
+        RetTy = isDepthImage ? T : CI->getType();
+        return std::string(kOCLBuiltinName::SampledReadImage) +
+               (T->isFloatingPointTy() ? 'f' : 'i');
+      },
+      [=](CallInst *NewCI) -> Instruction * {
+        if (isDepthImage)
+          return InsertElementInst::Create(
+              UndefValue::get(VectorType::get(NewCI->getType(), 4)), NewCI,
+              getSizet(M, 0), "", NewCI->getParent());
+        return NewCI;
+      },
+      &Attrs);
 }
 
 CallInst *

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -805,6 +805,10 @@ getInt64(Module *M, int64_t value) {
   return ConstantInt::get(Type::getInt64Ty(M->getContext()), value, true);
 }
 
+Constant *getFloat32(Module *M, float value) {
+  return ConstantFP::get(Type::getFloatTy(M->getContext()), value);
+}
+
 ConstantInt *
 getInt32(Module *M, int value) {
   return ConstantInt::get(Type::getInt32Ty(M->getContext()), value, true);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1429,24 +1429,20 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
         transValue(CI->getArgOperand(1), BB), BB);
       SPIRVValue *pZero = nullptr;
       SPIRVValue *pOne  = nullptr;
-      if (IsVector)
-      {
-          std::vector<SPIRVValue*> BVZero;
-          std::vector<SPIRVValue*> BVOne;
-          for (auto i = 0U; i < ResultTy->getVectorNumElements(); i++)
-          {
-              BVZero.push_back(transValue(
-                  ConstantInt::get(ResultTy->getScalarType(), 0), nullptr));
-              BVOne.push_back(transValue(
-                  ConstantInt::get(ResultTy->getScalarType(), ~0), nullptr));
-          }
-          pZero = BM->addCompositeConstant(BT, BVZero);
-          pOne  = BM->addCompositeConstant(BT, BVOne);
-      }
-      else
-      {
-          pZero = BM->addIntegerConstant(static_cast<SPIRVTypeInt*>(BT), 0);
-          pOne  = BM->addIntegerConstant(static_cast<SPIRVTypeInt*>(BT), 1);
+      if (IsVector) {
+        std::vector<SPIRVValue *> BVZero;
+        std::vector<SPIRVValue *> BVOne;
+        for (auto i = 0U; i < ResultTy->getVectorNumElements(); i++) {
+          BVZero.push_back(transValue(
+              ConstantInt::get(ResultTy->getScalarType(), 0), nullptr));
+          BVOne.push_back(transValue(
+              ConstantInt::get(ResultTy->getScalarType(), ~0), nullptr));
+        }
+        pZero = BM->addCompositeConstant(BT, BVZero);
+        pOne = BM->addCompositeConstant(BT, BVOne);
+      } else {
+        pZero = BM->addIntegerConstant(static_cast<SPIRVTypeInt *>(BT), 0);
+        pOne = BM->addIntegerConstant(static_cast<SPIRVTypeInt *>(BT), 1);
       }
       return BM->addSelectInst(Cmp, pOne, pZero, BB);
     } else if (isBinaryOpCode(OC)) {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1816,7 +1816,7 @@ public:
 // Image instructions
 _SPIRV_OP(SampledImage, true, 5)
 _SPIRV_OP(ImageSampleImplicitLod, true, 5, true)
-_SPIRV_OP(ImageSampleExplicitLod, true, 5, true)
+_SPIRV_OP(ImageSampleExplicitLod, true, 7, true, 2)
 _SPIRV_OP(ImageRead, true, 5)
 _SPIRV_OP(ImageWrite, false, 4)
 _SPIRV_OP(ImageQueryFormat, true, 4)

--- a/test/SPIRV/transcoding/OpImageSampleExplicitLod.ll
+++ b/test/SPIRV/transcoding/OpImageSampleExplicitLod.ll
@@ -1,0 +1,69 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func float @_Z11read_imagef16ocl_image2ddepth11ocl_samplerDv2_i(%opencl.image2d_depth_t
+
+; CHECK-SPIRV-DAG: 7 ImageSampleExplicitLod [[RetType:[0-9]+]] [[RetID:[0-9]+]] {{[0-9]+}} {{[0-9]+}} 2 {{[0-9]+}}
+; CHECK-SPIRV-DAG: 4 TypeVector [[RetType]] {{[0-9]+}} 4
+; CHECK-SPIRV: 5 CompositeExtract {{[0-9]+}} {{[0-9]+}} [[RetID]] 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_depth_t = type opaque
+
+; Function Attrs: nounwind
+define spir_kernel void @sample_kernel(%opencl.image2d_depth_t addrspace(1)* %input, i32 %imageSampler, float addrspace(1)* %xOffsets, float addrspace(1)* %yOffsets, float addrspace(1)* %results) #0 {
+entry:
+  %call = call spir_func i32 @_Z13get_global_idj(i32 0) #1
+  %call1 = call spir_func i32 @_Z13get_global_idj(i32 1) #1
+  %call2.tmp1 = call spir_func <2 x i32> @_Z13get_image_dim16ocl_image2ddepth(%opencl.image2d_depth_t addrspace(1)* %input)
+  %call2.old = extractelement <2 x i32> %call2.tmp1, i32 0
+  %mul = mul i32 %call1, %call2.old
+  %add = add i32 %mul, %call
+  %arrayidx = getelementptr inbounds float addrspace(1)* %xOffsets, i32 %add
+  %0 = load float addrspace(1)* %arrayidx, align 4
+  %conv = fptosi float %0 to i32
+  %vecinit = insertelement <2 x i32> undef, i32 %conv, i32 0
+  %arrayidx3 = getelementptr inbounds float addrspace(1)* %yOffsets, i32 %add
+  %1 = load float addrspace(1)* %arrayidx3, align 4
+  %conv4 = fptosi float %1 to i32
+  %vecinit5 = insertelement <2 x i32> %vecinit, i32 %conv4, i32 1
+  %call6.tmp.tmp = call spir_func float @_Z11read_imagef16ocl_image2ddepth11ocl_samplerDv2_i(%opencl.image2d_depth_t addrspace(1)* %input, i32 %imageSampler, <2 x i32> %vecinit5)
+  %arrayidx7 = getelementptr inbounds float addrspace(1)* %results, i32 %add
+  store float %call6.tmp.tmp, float addrspace(1)* %arrayidx7, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+declare spir_func float @_Z11read_imagef16ocl_image2ddepth11ocl_samplerDv2_i(%opencl.image2d_depth_t addrspace(1)*, i32, <2 x i32>) #0
+
+; Function Attrs: nounwind readnone
+declare spir_func i32 @_Z13get_global_idj(i32) #1
+
+; Function Attrs: nounwind
+declare spir_func <2 x i32> @_Z13get_image_dim16ocl_image2ddepth(%opencl.image2d_depth_t addrspace(1)*) #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!8}
+
+!0 = !{void (%opencl.image2d_depth_t addrspace(1)*, i32, float addrspace(1)*, float addrspace(1)*, float addrspace(1)*)* @sample_kernel, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 0, i32 1, i32 1, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"read_only", !"none", !"none", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"image2d_depth_t", !"sampler_t", !"float*", !"float*", !"float*"}
+!4 = !{!"kernel_arg_type_qual", !"", !"", !"", !"", !""}
+!5 = !{!"kernel_arg_base_type", !"image2d_depth_t", !"sampler_t", !"float*", !"float*", !"float*"}
+!6 = !{i32 2, i32 0}
+!7 = !{!" cl_khr_depth_images"}
+!8 = !{!"cl_images"}


### PR DESCRIPTION
Fixed following issues:
- According to SPIR-V specification OpImageSampleExplicitLod must always specify Image Operands argument with at least LOD mask operand.
- If image contains depth information read_image OpenCL built-in must return scalar value, where as OpImageSampleExplicitLod must always return vector type value. So in case of depth image, OpImageSampleExplicitLod is expected to return depth in 0 component of return vector.

Testing: added round-trip test that verifies that OpImageSampleExplicitLod return 4 element vector even for depth images and Image Operands are present.
