### PR TITLE
[SPIR-V] Fix translation of get_fence built-in function.

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -231,6 +231,13 @@ public:
   void visitCallForUnaryIntAsBool(CallInst *CI, StringRef MangledName,const std::string &DemangledName);
 
   void visitCallPrefetch(CallInst *CI, StringRef MangledName, const std::string& DemangledName);
+
+  /// Transforms get_mem_fence built-in to SPIR-V function and aligns result values with SPIR 1.2.
+  /// get_mem_fence(ptr) => __spirv_GenericPtrMemSemantics
+  /// GenericPtrMemSemantics valid values are 0x100, 0x200 and 0x300, where is
+  /// SPIR 1.2 defines them as 0x1, 0x2 and 0x3, so this function adjusts
+  /// GenericPtrMemSemantics results to SPIR 1.2 values.
+  void visitCallGetFence(CallInst *CI, StringRef MangledName, const std::string& DemangledName);
   
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
@@ -442,20 +449,23 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
     return;
   }
   if (DemangledName == kOCLBuiltinName::Dot &&
-      !isa<VectorType>(CI.getOperand(0)->getType())){
-      visitCallDot(&CI);
-      return;
+      !isa<VectorType>(CI.getOperand(0)->getType())) {
+    visitCallDot(&CI);
+    return;
   }
-   if (DemangledName == kOCLBuiltinName::IsFinite ||
+  if (DemangledName == kOCLBuiltinName::IsFinite ||
       DemangledName == kOCLBuiltinName::IsInf ||
       DemangledName == kOCLBuiltinName::IsNan ||
-      DemangledName == kOCLBuiltinName::IsNormal )
-  {
+      DemangledName == kOCLBuiltinName::IsNormal) {
     visitCallForUnaryIntAsBool(&CI, MangledName, DemangledName);
     return;
   }
-  if (DemangledName == kOCLBuiltinName::Prefetch){
+  if (DemangledName == kOCLBuiltinName::Prefetch) {
     visitCallPrefetch(&CI, MangledName, DemangledName);
+    return;
+  }
+  if (DemangledName == kOCLBuiltinName::GetFence) {
+    visitCallGetFence(&CI, MangledName, DemangledName);
     return;
   }
   visitCallBuiltinSimple(&CI, MangledName, DemangledName);
@@ -1252,6 +1262,20 @@ OCL20ToSPIRV::visitCallPrefetch(CallInst* CI, StringRef MangledName, const std::
         Args[1] = CI->getOperand(0);
         return kOCLBuiltinName::Prefetch;
     }, &Attrs);
+}
+
+void OCL20ToSPIRV::visitCallGetFence(CallInst *CI, StringRef MangledName,
+                                     const std::string &DemangledName) {
+  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
+  Op OC = OpNop;
+  OCLSPIRVBuiltinMap::find(DemangledName, &OC);
+  std::string SPIRVName = getSPIRVFuncName(OC);
+  mutateCallInstSPIRV(M, CI, [=](CallInst *, std::vector<Value *> &Args,
+                                 Type *&Ret) { return SPIRVName; },
+            [=](CallInst *NewCI) -> Instruction * {
+              return BinaryOperator::CreateLShr(NewCI, getInt32(M, 8), "", CI);
+            },
+            &Attrs);
 }
 
 }

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -322,7 +322,7 @@ public:
       UnmangledName == "mem_fence" ||
       UnmangledName.find("shuffle") == 0){
     addUnsignedArg(-1);
-    if (UnmangledName.find("get_fence") == 0){
+    if (UnmangledName.find(kOCLBuiltinName::GetFence) == 0){
       setArgAttr(0, SPIR::ATTR_CONST);
       addVoidPtrArg(0);
     }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1738,6 +1738,8 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction* BI,
   }
   if (OC == OpImageSampleExplicitLod)
     return postProcessOCLReadImage(BI, CI, DemangledName);
+  if (OC == OpGenericPtrMemSemantics)
+    return BinaryOperator::CreateShl(CI, getInt32(M, 8), "", BB);
   if (OC == OpBuildNDRange)
     return postProcessOCLBuildNDRange(BI, CI, DemangledName);
   if (SPIRVEnableStepExpansion &&

--- a/test/SPIRV/transcoding/OpGenericPtrMemSemantics.ll
+++ b/test/SPIRV/transcoding/OpGenericPtrMemSemantics.ll
@@ -1,0 +1,84 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: 4 GenericPtrMemSemantics {{[0-9]+}} [[ResID:[0-9]+]] {{[0-9]+}}
+; CHECK-SPIRV-NEXT: 5 ShiftRightLogical {{[0-9]+}} {{[0-9]+}} [[ResID]] {{[0-9]+}}
+
+; Note that round-trip conversion replaces 'get_fence (gentype *ptr)' built-in function with 'get_fence (const gentype *ptr)'.
+; CHECK-LLVM: call spir_func i32 @_Z9get_fencePKU3AS4v(i8
+; CHECK-LLVM-NEXT: shl
+; CHECK-LLVM-NEXT: lshr
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@gint = addrspace(1) global i32 1, align 4
+
+; Function Attrs: nounwind readnone
+define spir_func i32 @isFenceValid(i32 %fence) #0 {
+entry:
+  %switch = icmp ult i32 %fence, 4
+  %. = zext i1 %switch to i32
+  ret i32 %.
+}
+
+; Function Attrs: nounwind
+define spir_func i32 @f4(i32 %val, i32 addrspace(4)* %ptr) #1 {
+entry:
+  %0 = bitcast i32 addrspace(4)* %ptr to i8 addrspace(4)*
+  %call = tail call spir_func i32 @_Z9get_fencePU3AS4v(i8 addrspace(4)* %0) #3
+  %switch.i = icmp ult i32 %call, 4
+  %1 = load i32 addrspace(4)* %ptr, align 4
+  %cmp = icmp eq i32 %1, %val
+  %and4 = and i1 %switch.i, %cmp
+  %and = zext i1 %and4 to i32
+  %2 = xor i32 %and, 1
+  ret i32 %2
+}
+
+declare spir_func i32 @_Z9get_fencePU3AS4v(i8 addrspace(4)*) #2
+
+; Function Attrs: nounwind
+define spir_kernel void @testKernel(i32 addrspace(1)* nocapture %results) #1 {
+entry:
+  %call = tail call spir_func i32 @_Z13get_global_idj(i32 0) #3
+  %0 = load i32 addrspace(1)* @gint, align 4
+  %call.i = tail call spir_func i32 @_Z9get_fencePU3AS4v(i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast (i32 addrspace(1)* @gint to i8 addrspace(1)*) to i8 addrspace(4)*)) #3
+  %switch.i.i = icmp ult i32 %call.i, 4
+  %1 = load i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @gint to i32 addrspace(4)*), align 4
+  %cmp.i = icmp eq i32 %1, %0
+  %and4.i = and i1 %switch.i.i, %cmp.i
+  %cond = zext i1 %and4.i to i32
+  %arrayidx = getelementptr inbounds i32 addrspace(1)* %results, i32 %call
+  store i32 %cond, i32 addrspace(1)* %arrayidx, align 4
+  ret void
+}
+
+declare spir_func i32 @_Z13get_global_idj(i32) #2
+
+attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (i32 addrspace(1)*)* @testKernel, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"uint*"}
+!4 = !{!"kernel_arg_base_type", !"uint*"}
+!5 = !{!"kernel_arg_type_qual", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
SPIR 1.2 defines valid values for get_fence function to be 1, 2 or 3.
get_fence is translated to OpGenericPtrMemSemantics, which returns 0x100, 0x200 or 0x300,
so additional shift operations are added to align return values between OpenCL built-in function and SPIR-V instruction.
