### PR TITLE
[Reader] Fix mangling of device execution built-ins with local memory arguments

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -327,7 +327,6 @@ void
 mutateFunctionOCL(Function *F,
     std::function<std::string (CallInst *, std::vector<Value *> &)>ArgMutate,
     AttributeSet *Attrs = nullptr);
-
 } // namespace OCLUtil
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -988,14 +988,11 @@ SPIRVToLLVM::postProcessOCLBuiltinWithFuncPointer(Function* F,
   std::set<Value *> InvokeFuncPtrs;
   mutateFunctionOCL (F, [=, &InvokeFuncPtrs](
       CallInst *CI, std::vector<Value *> &Args) {
-    auto ALoc = Args.begin();
-    for (auto E = Args.end(); ALoc != E; ++ALoc) {
-      if (isFunctionPointerType((*ALoc)->getType())) {
-        assert(isa<Function>(*ALoc) && "Invalid function pointer usage");
-        break;
-      }
-    }
-    assert (ALoc != Args.end());
+    auto ALoc = std::find_if(Args.begin(), Args.end(), [](Value * elem) {
+        return isFunctionPointerType(elem->getType());
+      });
+    assert(ALoc != Args.end() && "Buit-in must accept a pointer to function");
+    assert(isa<Function>(*ALoc) && "Invalid function pointer usage");
     Value *Ctx = ALoc[1];
     Value *CtxLen = ALoc[2];
     Value *CtxAlign = ALoc[3];

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -264,12 +264,13 @@ getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes,
     StringRef Name, BuiltinFuncMangleInfo *Mangle, AttributeSet *Attrs,
     bool takeName) {
   std::string MangledName = Name;
-  if (Mangle)
+  bool isVarArg = false;
+  if (Mangle) {
     MangledName = mangleBuiltin(Name, ArgTypes, Mangle);
-  FunctionType *FT = FunctionType::get(
-      RetTy,
-      ArgTypes,
-      false);
+    isVarArg = 0 <= Mangle->getVarArg();
+    if(isVarArg) ArgTypes = ArgTypes.slice(0, Mangle->getVarArg());
+  }
+  FunctionType *FT = FunctionType::get(RetTy, ArgTypes, isVarArg);
   Function *F = M->getFunction(MangledName);
   if (!takeName && F && F->getFunctionType() != FT && Mangle != nullptr) {
     std::string S;
@@ -691,6 +692,7 @@ CallInst *
 addCallInst(Module *M, StringRef FuncName, Type *RetTy, ArrayRef<Value *> Args,
     AttributeSet *Attrs, Instruction *Pos, BuiltinFuncMangleInfo *Mangle,
     StringRef InstName, bool TakeFuncName) {
+
   auto F = getOrCreateFunction(M, RetTy, getTypes(Args),
       FuncName, Mangle, Attrs, TakeFuncName);
   auto CI = CallInst::Create(F, Args, InstName, Pos);
@@ -1030,8 +1032,21 @@ transTypeDesc(Type *Ty, const BuiltinArgTypeMangleInfo &Info) {
 
       auto Prim = getOCLTypePrimitiveEnum(TyName);
       if (StructTy->isOpaque()) {
-        if (TyName == "opencl.block")
-          EPT = new SPIR::BlockType;
+        if (TyName == "opencl.block") {
+          auto BlockTy = new SPIR::BlockType;
+          // Handle block with local memory arguments according to OpenCL 2.0 spec.
+          if(Info.IsLocalArgBlock) {
+            SPIR::RefParamType VoidTyRef(new SPIR::PrimitiveType(SPIR::PRIMITIVE_VOID));
+            auto VoidPtrTy = new SPIR::PointerType(VoidTyRef);
+            VoidPtrTy->setAddressSpace(SPIR::ATTR_LOCAL);
+            // "__local void *"
+            BlockTy->setParam(0, SPIR::RefParamType(VoidPtrTy));
+            // "..."
+            BlockTy->setParam(1, SPIR::RefParamType(
+              new SPIR::PrimitiveType(SPIR::PRIMITIVE_VAR_ARG)));
+          }
+          EPT = BlockTy;
+        }
         else if (Prim != SPIR::PRIMITIVE_NONE)
           EPT = new SPIR::PrimitiveType(Prim);
       } else if (Prim == SPIR::PRIMITIVE_NDRANGE_T)
@@ -1201,13 +1216,28 @@ mangleBuiltin(const std::string &UniqName,
   SPIR::NameMangler Mangler(SPIR::SPIR20);
   SPIR::FunctionDescriptor FD;
   FD.name = BtnInfo->getUnmangledName();
-  for (unsigned I = 0, E = ArgTypes.size(); I != E; ++I) {
-    auto T = ArgTypes[I];
-    FD.parameters.emplace_back(transTypeDesc(T, BtnInfo->getTypeMangleInfo(I)));
-  }
-  if (FD.parameters.empty())
-    FD.parameters.emplace_back(SPIR::RefParamType(new SPIR::PrimitiveType(
+
+  if (ArgTypes.empty()) {
+    // Function signature cannot be ()(void, ...) so if there is an ellipsis
+    // it must be ()(...)
+    if(BtnInfo->getVarArg() < 0) {
+      FD.parameters.emplace_back(SPIR::RefParamType(new SPIR::PrimitiveType(
         SPIR::PRIMITIVE_VOID)));
+    }
+  } else {
+    for (unsigned I = 0, E = ArgTypes.size();
+         I != E && I != BtnInfo->getVarArg(); ++I) {
+      auto T = ArgTypes[I];
+      FD.parameters.emplace_back(transTypeDesc(T, BtnInfo->getTypeMangleInfo(I)));
+    }
+  }
+  // Ellipsis must be the last argument of any function
+  if(0 <= BtnInfo->getVarArg()) {
+    assert(BtnInfo->getVarArg() <= ArgTypes.size()
+           && "invalid index of an ellipsis");
+    FD.parameters.emplace_back(SPIR::RefParamType(new SPIR::PrimitiveType(
+        SPIR::PRIMITIVE_VAR_ARG)));
+  }
   Mangler.mangle(FD, MangledName);
   DEBUG(dbgs() << MangledName << '\n');
   return MangledName;

--- a/test/SPIRV/transcoding/device_execution_overloading.ll
+++ b/test/SPIRV/transcoding/device_execution_overloading.ll
@@ -1,0 +1,203 @@
+;; bash$ cat device_execution_overloading.cl
+;; void device_kernel_with_local_args(__local float* ptr0, __local float* ptr1) {
+;;   *ptr0 = 0;
+;;   *ptr1 = 1;
+;; }
+;;
+;; void device_kernel(__global float* ptr) {
+;;   *ptr = 3;
+;; }
+;;
+;; __kernel void host_kernel(uint size, __global float* ptr) {
+;;   void(^block_with_local)(__local void*, __local void*) = ^(__local void* ptr0, __local void* ptr1){
+;;     device_kernel_with_local_args(ptr0, ptr1);
+;;   };
+;;
+;;   void(^block)(void) = ^{
+;;     device_kernel(ptr);
+;;   };
+;;
+;n;   uint wgSize = get_kernel_work_group_size(block_with_local);
+;;   uint prefMul =  get_kernel_preferred_work_group_size_multiple(block_with_local);
+;;   enqueue_kernel(get_default_queue(), CLK_ENQUEUE_FLAGS_WAIT_KERNEL, ndrange_1D(1),
+;;                  0, NULL, NULL, block_with_local, size, wgSize * prefMul);
+;;
+;;   wgSize = get_kernel_work_group_size(block);
+;;   prefMul =  get_kernel_preferred_work_group_size_multiple(block);
+;;   enqueue_kernel(get_default_queue(), CLK_ENQUEUE_FLAGS_WAIT_KERNEL, ndrange_1D(1),
+;;                  0, NULL, NULL, block);
+;; }
+;; bash$
+;;$PATH_TO_GEN/bin/clang -cc1 -x cl -O0 -cl-std=CL2.0 -triple spir64-unknonw-unknown -include $PATH_TO_GEN/lib/clang/3.6.1/include/opencl-20.h -emit-llvm device_execution_overloading.cl -o device_execution_overloading.ll
+
+;; Test overloading of device exectuion built-ins is OK after translation from SPIR-V
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; ModuleID = 'device_execution_overloading.cl'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknonw-unknown"
+
+%opencl.block = type opaque
+%struct.ndrange_t = type { i32, [3 x i64], [3 x i64], [3 x i64] }
+%opencl.queue_t = type opaque
+%opencl.clk_event_t = type opaque
+
+; Function Attrs: nounwind
+define spir_func void @device_kernel_with_local_args(float addrspace(3)* %ptr0, float addrspace(3)* %ptr1) #0 {
+entry:
+  %ptr0.addr = alloca float addrspace(3)*, align 8
+  %ptr1.addr = alloca float addrspace(3)*, align 8
+  store float addrspace(3)* %ptr0, float addrspace(3)** %ptr0.addr, align 8
+  store float addrspace(3)* %ptr1, float addrspace(3)** %ptr1.addr, align 8
+  %0 = load float addrspace(3)** %ptr0.addr, align 8
+  store float 0.000000e+00, float addrspace(3)* %0, align 4
+  %1 = load float addrspace(3)** %ptr1.addr, align 8
+  store float 1.000000e+00, float addrspace(3)* %1, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_func void @device_kernel(float addrspace(1)* %ptr) #0 {
+entry:
+  %ptr.addr = alloca float addrspace(1)*, align 8
+  store float addrspace(1)* %ptr, float addrspace(1)** %ptr.addr, align 8
+  %0 = load float addrspace(1)** %ptr.addr, align 8
+  store float 3.000000e+00, float addrspace(1)* %0, align 4
+  ret void
+}
+
+; CHECK: @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE
+; CHECK: @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE
+; CHECK: @_Z14enqueue_kernel9ocl_queue{{.*}}9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvPU3AS3vzEjz
+
+; CHECK: @_Z26get_kernel_work_group_sizeU13block_pointerFvvE
+; CHECK: @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvvE
+; CHECK: @_Z14enqueue_kernel9ocl_queue{{.*}}9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvvE
+
+; Function Attrs: nounwind
+define spir_kernel void @host_kernel(i32 %size, float addrspace(1)* %ptr) #0 {
+entry:
+  %size.addr = alloca i32, align 4
+  %ptr.addr = alloca float addrspace(1)*, align 8
+  %block_with_local = alloca %opencl.block*, align 8
+  %block = alloca %opencl.block*, align 8
+  %captured = alloca <{ float addrspace(1)* }>, align 8
+  %wgSize = alloca i32, align 4
+  %prefMul = alloca i32, align 4
+  %agg.tmp = alloca %struct.ndrange_t, align 8
+  %agg.tmp8 = alloca %struct.ndrange_t, align 8
+  store i32 %size, i32* %size.addr, align 4
+  store float addrspace(1)* %ptr, float addrspace(1)** %ptr.addr, align 8
+  %0 = call %opencl.block* @spir_block_bind(i8* bitcast (void (i8*, i8 addrspace(3)*, i8 addrspace(3)*)* @__host_kernel_block_invoke to i8*), i32 0, i32 0, i8* null)
+  store %opencl.block* %0, %opencl.block** %block_with_local, align 8
+  %block.captured = getelementptr inbounds <{ float addrspace(1)* }>* %captured, i32 0, i32 0
+  %1 = load float addrspace(1)** %ptr.addr, align 8
+  store float addrspace(1)* %1, float addrspace(1)** %block.captured, align 8
+  %2 = bitcast <{ float addrspace(1)* }>* %captured to i8*
+  %3 = call %opencl.block* @spir_block_bind(i8* bitcast (void (i8*)* @__host_kernel_block_invoke_2 to i8*), i32 8, i32 8, i8* %2)
+  store %opencl.block* %3, %opencl.block** %block, align 8
+  %4 = load %opencl.block** %block_with_local, align 8
+  %call = call spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE(%opencl.block* %4)
+  store i32 %call, i32* %wgSize, align 4
+  %5 = load %opencl.block** %block_with_local, align 8
+  %call2 = call spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE(%opencl.block* %5)
+  store i32 %call2, i32* %prefMul, align 4
+  %call3 = call spir_func %opencl.queue_t* @_Z17get_default_queuev()
+  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret %agg.tmp, i64 1)
+  %6 = load %opencl.block** %block_with_local, align 8
+  %7 = load i32* %size.addr, align 4
+  %8 = load i32* %wgSize, align 4
+  %9 = load i32* %prefMul, align 4
+  %mul = mul i32 %8, %9
+  %call4 = call spir_func i32 (%opencl.queue_t*, i32, %struct.ndrange_t*, i32, %opencl.clk_event_t**, %opencl.clk_event_t**, %opencl.block*, i32, ...)* @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvPU3AS3vzEjz(%opencl.queue_t* %call3, i32 241, %struct.ndrange_t* byval %agg.tmp, i32 0, %opencl.clk_event_t** null, %opencl.clk_event_t** null, %opencl.block* %6, i32 %7, i32 %mul)
+  %10 = load %opencl.block** %block, align 8
+  %call5 = call spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvvE(%opencl.block* %10)
+  store i32 %call5, i32* %wgSize, align 4
+  %11 = load %opencl.block** %block, align 8
+  %call6 = call spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvvE(%opencl.block* %11)
+  store i32 %call6, i32* %prefMul, align 4
+  %call7 = call spir_func %opencl.queue_t* @_Z17get_default_queuev()
+  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret %agg.tmp8, i64 1)
+  %12 = load %opencl.block** %block, align 8
+  %call9 = call spir_func i32 @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvvE(%opencl.queue_t* %call7, i32 241, %struct.ndrange_t* byval %agg.tmp8, i32 0, %opencl.clk_event_t** null, %opencl.clk_event_t** null, %opencl.block* %12)
+  ret void
+}
+
+; Function Attrs: nounwind
+define internal spir_func void @__host_kernel_block_invoke(i8* %.block_descriptor, i8 addrspace(3)* %ptr0, i8 addrspace(3)* %ptr1) #0 {
+entry:
+  %.block_descriptor.addr = alloca i8*, align 8
+  %ptr0.addr = alloca i8 addrspace(3)*, align 8
+  %ptr1.addr = alloca i8 addrspace(3)*, align 8
+  %block.addr = alloca <{}>*, align 8
+  store i8* %.block_descriptor, i8** %.block_descriptor.addr, align 8
+  %0 = load i8** %.block_descriptor.addr
+  store i8 addrspace(3)* %ptr0, i8 addrspace(3)** %ptr0.addr, align 8
+  store i8 addrspace(3)* %ptr1, i8 addrspace(3)** %ptr1.addr, align 8
+  %block = bitcast i8* %.block_descriptor to <{}>*
+  store <{}>* %block, <{}>** %block.addr, align 8
+  %1 = load i8 addrspace(3)** %ptr0.addr, align 8
+  %2 = bitcast i8 addrspace(3)* %1 to float addrspace(3)*
+  %3 = load i8 addrspace(3)** %ptr1.addr, align 8
+  %4 = bitcast i8 addrspace(3)* %3 to float addrspace(3)*
+  call spir_func void @device_kernel_with_local_args(float addrspace(3)* %2, float addrspace(3)* %4)
+  ret void
+}
+
+declare %opencl.block* @spir_block_bind(i8*, i32, i32, i8*)
+
+; Function Attrs: nounwind
+define internal spir_func void @__host_kernel_block_invoke_2(i8* %.block_descriptor) #0 {
+entry:
+  %.block_descriptor.addr = alloca i8*, align 8
+  %block.addr = alloca <{ float addrspace(1)* }>*, align 8
+  store i8* %.block_descriptor, i8** %.block_descriptor.addr, align 8
+  %0 = load i8** %.block_descriptor.addr
+  %block = bitcast i8* %.block_descriptor to <{ float addrspace(1)* }>*
+  store <{ float addrspace(1)* }>* %block, <{ float addrspace(1)* }>** %block.addr, align 8
+  %block.capture.addr = getelementptr inbounds <{ float addrspace(1)* }>* %block, i32 0, i32 0
+  %1 = load float addrspace(1)** %block.capture.addr, align 8
+  call spir_func void @device_kernel(float addrspace(1)* %1)
+  ret void
+}
+
+declare spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE(%opencl.block*) #1
+
+declare spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE(%opencl.block*) #1
+
+declare spir_func i32 @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvPU3AS3vzEjz(%opencl.queue_t*, i32, %struct.ndrange_t* byval, i32, %opencl.clk_event_t**, %opencl.clk_event_t**, %opencl.block*, i32, ...) #1
+
+declare spir_func %opencl.queue_t* @_Z17get_default_queuev() #1
+
+declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret, i64) #1
+
+declare spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvvE(%opencl.block*) #1
+
+declare spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvvE(%opencl.block*) #1
+
+declare spir_func i32 @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvvE(%opencl.queue_t*, i32, %struct.ndrange_t* byval, i32, %opencl.clk_event_t**, %opencl.clk_event_t**, %opencl.block*) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (i32, float addrspace(1)*)* @host_kernel, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 0, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"uint", !"float*"}
+!4 = !{!"kernel_arg_base_type", !"uint", !"float*"}
+!5 = !{!"kernel_arg_type_qual", !"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}

--- a/test/SPIRV/transcoding/device_execution_simple_local_memory.ll
+++ b/test/SPIRV/transcoding/device_execution_simple_local_memory.ll
@@ -1,0 +1,137 @@
+;; bash$ cat repro.cl
+;; void device_kernel(__local float* ptr0, __local float* ptr1) {
+;;   *ptr0 = 0;
+;;   *ptr1 = 1;
+;; }
+;;
+;; __kernel void host_kernel(uint size) {
+;;   void(^block)(__local void*, __local void*) = ^(__local void* ptr0, __local void* ptr1){
+;;     device_kernel(ptr0, ptr1);
+;;   };
+;;
+;;   uint wgSize = get_kernel_work_group_size(block);
+;;   uint prefMul =  get_kernel_preferred_work_group_size_multiple(block);
+;;   enqueue_kernel(get_default_queue(), CLK_ENQUEUE_FLAGS_WAIT_KERNEL, ndrange_1D(1),
+;;                  0, NULL, NULL, block, size, wgSize * prefMul);
+;; }
+;; bash$
+;; bash$ export PATH_TO_INCLUDE= $PATH_TO_GEN/lib/clang/3.6.1/include
+;; bash$ $PATH_TO_GEN/bin/clang -cc1 -x cl -cl-std=CL2.0 -triple spir64-unknonw-unknown -emit-llvm  -include opencl-20.h  repro.cl -o device_execution.ll
+
+;; 1. Check mangling of device execution built-ins for blocks with local memory arguments
+;; 2. Check there is an enqueue_kernel with ellipsis
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s
+
+; ModuleID = 'repro.cl'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknonw-unknown"
+
+%opencl.block = type opaque
+%struct.ndrange_t = type { i32, [3 x i64], [3 x i64], [3 x i64] }
+%opencl.queue_t = type opaque
+%opencl.clk_event_t = type opaque
+
+; Function Attrs: nounwind
+define spir_func void @device_kernel(float addrspace(3)* %ptr0, float addrspace(3)* %ptr1) #0 {
+entry:
+  %ptr0.addr = alloca float addrspace(3)*, align 8
+  %ptr1.addr = alloca float addrspace(3)*, align 8
+  store float addrspace(3)* %ptr0, float addrspace(3)** %ptr0.addr, align 8
+  store float addrspace(3)* %ptr1, float addrspace(3)** %ptr1.addr, align 8
+  %0 = load float addrspace(3)** %ptr0.addr, align 8
+  store float 0.000000e+00, float addrspace(3)* %0, align 4
+  %1 = load float addrspace(3)** %ptr1.addr, align 8
+  store float 1.000000e+00, float addrspace(3)* %1, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @host_kernel(i32 %size) #0 {
+entry:
+  %size.addr = alloca i32, align 4
+  %block = alloca %opencl.block*, align 8
+  %wgSize = alloca i32, align 4
+  %prefMul = alloca i32, align 4
+  %agg.tmp = alloca %struct.ndrange_t, align 8
+  store i32 %size, i32* %size.addr, align 4
+  %0 = call %opencl.block* @spir_block_bind(i8* bitcast (void (i8*, i8 addrspace(3)*, i8 addrspace(3)*)* @__host_kernel_block_invoke to i8*), i32 0, i32 0, i8* null)
+  store %opencl.block* %0, %opencl.block** %block, align 8
+  %1 = load %opencl.block** %block, align 8
+; CHECK: call {{.*}} @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE
+  %call = call spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE(%opencl.block* %1)
+  store i32 %call, i32* %wgSize, align 4
+  %2 = load %opencl.block** %block, align 8
+; CHECK: call {{.*}} @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE
+  %call1 = call spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE(%opencl.block* %2)
+  store i32 %call1, i32* %prefMul, align 4
+  %call2 = call spir_func %opencl.queue_t* @_Z17get_default_queuev()
+  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret %agg.tmp, i64 1)
+  %3 = load %opencl.block** %block, align 8
+  %4 = load i32* %size.addr, align 4
+  %5 = load i32* %wgSize, align 4
+  %6 = load i32* %prefMul, align 4
+  %mul = mul i32 %5, %6
+; CHECK: call {{.*}} @_Z14enqueue_kernel{{.*}}U13block_pointerFvPU3AS3vzEjz({{.*}}, %opencl.block* {{.*}}, i32 {{.*}}, i32 {{.*}})
+  %call3 = call spir_func i32 (%opencl.queue_t*, i32, %struct.ndrange_t*, i32, %opencl.clk_event_t**, %opencl.clk_event_t**, %opencl.block*, i32, ...)* @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvPU3AS3vzEjz(%opencl.queue_t* %call2, i32 241, %struct.ndrange_t* byval %agg.tmp, i32 0, %opencl.clk_event_t** null, %opencl.clk_event_t** null, %opencl.block* %3, i32 %4, i32 %mul)
+  ret void
+}
+
+; Function Attrs: nounwind
+; CHECK-LABEL: define {{.*}} @__host_kernel_block_invoke
+define internal spir_func void @__host_kernel_block_invoke(i8* %.block_descriptor, i8 addrspace(3)* %ptr0, i8 addrspace(3)* %ptr1) #0 {
+entry:
+  %.block_descriptor.addr = alloca i8*, align 8
+  %ptr0.addr = alloca i8 addrspace(3)*, align 8
+  %ptr1.addr = alloca i8 addrspace(3)*, align 8
+  %block.addr = alloca <{}>*, align 8
+  store i8* %.block_descriptor, i8** %.block_descriptor.addr, align 8
+  %0 = load i8** %.block_descriptor.addr
+  store i8 addrspace(3)* %ptr0, i8 addrspace(3)** %ptr0.addr, align 8
+  store i8 addrspace(3)* %ptr1, i8 addrspace(3)** %ptr1.addr, align 8
+  %block = bitcast i8* %.block_descriptor to <{}>*
+  store <{}>* %block, <{}>** %block.addr, align 8
+  %1 = load i8 addrspace(3)** %ptr0.addr, align 8
+  %2 = bitcast i8 addrspace(3)* %1 to float addrspace(3)*
+  %3 = load i8 addrspace(3)** %ptr1.addr, align 8
+  %4 = bitcast i8 addrspace(3)* %3 to float addrspace(3)*
+  call spir_func void @device_kernel(float addrspace(3)* %2, float addrspace(3)* %4)
+  ret void
+}
+
+declare %opencl.block* @spir_block_bind(i8*, i32, i32, i8*)
+
+declare spir_func i32 @_Z26get_kernel_work_group_sizeU13block_pointerFvPU3AS3vzE(%opencl.block*) #1
+
+declare spir_func i32 @_Z45get_kernel_preferred_work_group_size_multipleU13block_pointerFvPU3AS3vzE(%opencl.block*) #1
+
+; CHECK: declare {{.*}} @_Z14enqueue_kernel{{.*}}U13block_pointerFvPU3AS3vzEjz({{.*}}, %opencl.block*, i32, ...)
+declare spir_func i32 @_Z14enqueue_kernel9ocl_queuei9ndrange_tjPK12ocl_clkeventP12ocl_clkeventU13block_pointerFvPU3AS3vzEjz(%opencl.queue_t*, i32, %struct.ndrange_t* byval, i32, %opencl.clk_event_t**, %opencl.clk_event_t**, %opencl.block*, i32, ...) #1
+
+declare spir_func %opencl.queue_t* @_Z17get_default_queuev() #1
+
+declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret, i64) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (i32)* @host_kernel, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"uint"}
+!4 = !{!"kernel_arg_base_type", !"uint"}
+!5 = !{!"kernel_arg_type_qual", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
According to OpenCL 2.0 specification some device execution built-ins may have
ellipsis in the arguments along with a block with local memory arguments. These
built-ins apparently must be mangled differenlty then built-ins w\o blocks
with local memory arguments so BE could be able to handle them properly.

uint get_kernel_work_group_size (void (^block)(local void *, …));

uint get_kernel_preferred_ work_group_size_multiple (
 void (^block)(local void *, …));

int enqueue_kernel (queue_t queue, kernel_enqueue_flags_t flags,
                    const ndrange_t ndrange,
                    uint num_events_in_wait_list,
                    const clk_event_t *event_wait_list,
                    clk_event_t *event_ret,
                    void (^block)(local void *, ...…),
                    uint size0, ...)

Unfortuantely SPIR 2.0 specification doesn't state anything about these
built-ins except the generic sentece about built-ins mangling. So, this
commit follows SPIR 2.0 generator and SPIR 2.0 spec. and Itanium C++ ABI
spec. to mangle these built-ins.
