### PR TITLE
Revert generator fixes

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -43,7 +43,6 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Instruction.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
@@ -113,10 +112,6 @@ public:
   ///   __spirv_MemoryBarrier(map(scope), map(flag)|map(order))
   void transMemoryBarrier(CallInst *CI, AtomicWorkItemFenceLiterals);
 
-  /// Transform all to __spirv_Op(All|Any).  Note that the types mismatch so
-  // some extra code is emitted to convert between the two.
-  void visitCallAllAny(spv::Op OC, CallInst *CI);
-
   /// Transform atomic_* to __spirv_Atomic*.
   /// atomic_x(ptr_arg, args, order, scope) =>
   ///   __spirv_AtomicY(ptr_arg, map(order), map(scope), args)
@@ -165,7 +160,7 @@ public:
 
   /// Transform get_image_{width|height|depth|dim}.
   /// get_image_xxx(...) =>
-  ///   dimension = __spirv_ImageQuerySizeLod_R{ReturnType}(...);
+  ///   dimension = __spirv_ImageQuerySizeLod(...);
   ///   return dimension.{x|y|z};
   void visitCallGetImageSize(CallInst *CI, StringRef MangledName,
     const std::string &DemangledName);
@@ -225,12 +220,6 @@ public:
   void visitCallVecLoadStore(CallInst *CI, StringRef MangledName,
       const std::string &DemangledName);
 
-  /// Transforms OpDot instructions with a scalar type to a fmul instruction
-  void visitCallDot(CallInst *CI);
-
-  void visitCallForUnaryIntAsBool(CallInst *CI, StringRef MangledName,const std::string &DemangledName);
-
-  void visitCallPrefetch(CallInst *CI, StringRef MangledName, const std::string& DemangledName);
 
   /// Transforms get_mem_fence built-in to SPIR-V function and aligns result values with SPIR 1.2.
   /// get_mem_fence(ptr) => __spirv_GenericPtrMemSemantics
@@ -238,7 +227,6 @@ public:
   /// SPIR 1.2 defines them as 0x1, 0x2 and 0x3, so this function adjusts
   /// GenericPtrMemSemantics results to SPIR 1.2 values.
   void visitCallGetFence(CallInst *CI, StringRef MangledName, const std::string& DemangledName);
-  
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
     I.eraseFromParent();
@@ -357,14 +345,6 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
     visitCallNDRange(&CI, DemangledName);
     return;
   }
-  if (DemangledName == kOCLBuiltinName::All) {
-      visitCallAllAny(OpAll, &CI);
-      return;
-  }
-  if (DemangledName == kOCLBuiltinName::Any) {
-      visitCallAllAny(OpAny, &CI);
-      return;
-  }
   if (DemangledName.find(kOCLBuiltinName::AsyncWorkGroupCopy) == 0 ||
       DemangledName.find(kOCLBuiltinName::AsyncWorkGroupStridedCopy) == 0) {
     visitCallAsyncWorkGroupCopy(&CI, DemangledName);
@@ -397,8 +377,7 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
   if (DemangledName == kOCLBuiltinName::GetImageWidth ||
       DemangledName == kOCLBuiltinName::GetImageHeight ||
       DemangledName == kOCLBuiltinName::GetImageDepth ||
-      DemangledName == kOCLBuiltinName::GetImageDim   ||
-      DemangledName == kOCLBuiltinName::GetImageArraySize) {
+      DemangledName == kOCLBuiltinName::GetImageDim) {
     visitCallGetImageSize(&CI, MangledName, DemangledName);
     return;
   }
@@ -446,22 +425,6 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
   if (DemangledName == kOCLBuiltinName::WorkGroupBarrier ||
       DemangledName == kOCLBuiltinName::Barrier) {
     visitCallWorkGroupBarrier(&CI);
-    return;
-  }
-  if (DemangledName == kOCLBuiltinName::Dot &&
-      !isa<VectorType>(CI.getOperand(0)->getType())) {
-    visitCallDot(&CI);
-    return;
-  }
-  if (DemangledName == kOCLBuiltinName::IsFinite ||
-      DemangledName == kOCLBuiltinName::IsInf ||
-      DemangledName == kOCLBuiltinName::IsNan ||
-      DemangledName == kOCLBuiltinName::IsNormal) {
-    visitCallForUnaryIntAsBool(&CI, MangledName, DemangledName);
-    return;
-  }
-  if (DemangledName == kOCLBuiltinName::Prefetch) {
-    visitCallPrefetch(&CI, MangledName, DemangledName);
     return;
   }
   if (DemangledName == kOCLBuiltinName::GetFence) {
@@ -563,44 +526,6 @@ OCL20ToSPIRV::visitCallAtomicInit(CallInst* CI) {
   ST->takeName(CI);
   CI->dropAllReferences();
   CI->eraseFromParent();
-}
-
-void
-OCL20ToSPIRV::visitCallAllAny(spv::Op OC, CallInst* CI) {
-  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-
-  auto Args = getArguments(CI);
-  assert(Args.size() == 1);
-
-  auto *pArgTy = Args[0]->getType();
-  auto zero = ConstantInt::get(pArgTy->getScalarType(), 0);
-  auto RHS = isa<VectorType>(pArgTy) ?
-      ConstantVector::getSplat(
-        cast<VectorType>(pArgTy)->getNumElements(), zero) : zero;
-
-  auto *pCmp = CmpInst::Create(CmpInst::ICmp, CmpInst::ICMP_SLT,
-      Args[0], RHS, "cast", CI);
-
-  if (!isa<VectorType>(pArgTy)) {
-    auto *pCast = CastInst::CreateZExtOrBitCast(pCmp, Type::getInt32Ty(*Ctx),
-                                                "", pCmp->getNextNode());
-    CI->replaceAllUsesWith(pCast);
-    CI->eraseFromParent();
-  } else {
-    mutateCallInstSPIRV(
-        M, CI,
-        [&](CallInst *, std::vector<Value *> &Args, Type *&Ret) {
-          Args[0] = pCmp;
-          Ret = Type::getInt1Ty(*Ctx);
-
-          return getSPIRVFuncName(OC);
-        },
-        [&](CallInst *CI) -> Instruction * {
-          return CastInst::CreateZExtOrBitCast(CI, Type::getInt32Ty(*Ctx), "",
-              CI->getNextNode());
-        },
-        &Attrs);
-  }
 }
 
 void
@@ -998,16 +923,14 @@ OCL20ToSPIRV::visitCallGetImageSize(CallInst* CI,
       assert(IsImg);
       Desc = map<SPIRVTypeImageDescriptor>(TyName.str());
       Dim = getImageDimension(Desc.Dim) + Desc.Arrayed;
-      Ret = CI->getType()->isIntegerTy(64) ?
-          Type::getInt64Ty(*Ctx) :
-          Type::getInt32Ty(*Ctx);
+      Ret = Type::getInt32Ty(*Ctx);
       if (Dim > 1)
         Ret = VectorType::get(Ret, Dim);
       if (Desc.Dim == DimBuffer)
-          return getSPIRVFuncName(OpImageQuerySize, CI->getType());
+        return getSPIRVFuncName(OpImageQuerySize);
       else {
         Args.push_back(getInt32(M, 0));
-        return getSPIRVFuncName(OpImageQuerySizeLod, CI->getType());
+        return getSPIRVFuncName(OpImageQuerySizeLod);
       }
     },
     [&](CallInst *NCI)->Instruction * {
@@ -1207,62 +1130,6 @@ OCL20ToSPIRV::visitCallVecLoadStore(CallInst* CI,
   transBuiltin(CI, Info);
 }
 
-void
-OCL20ToSPIRV::visitCallDot(CallInst* CI){
-    IRBuilder<> Builder(CI);
-    Value *FMulVal = Builder.CreateFMul(CI->getOperand(0), CI->getOperand(1));
-    CI->replaceAllUsesWith(FMulVal);
-    CI->dropAllReferences();
-    CI->removeFromParent();
-}
-
-void OCL20ToSPIRV::visitCallForUnaryIntAsBool(CallInst *CI, StringRef MangledName,
-  const std::string &DemangledName) {
-
-  std::vector<Type *> ArgTys;
-  std::vector<Value*> Args;
-  for (size_t I = 0, E = CI->getNumArgOperands(); I != E; ++I) {
-    ArgTys.push_back(CI->getArgOperand(I)->getType());
-    Args.push_back(CI->getArgOperand(I));
-  }
-
-  spv::Op OC = OpNop;
-  
-  if(DemangledName == kOCLBuiltinName::IsFinite) OC = OpIsFinite;
-  if(DemangledName == kOCLBuiltinName::IsInf) OC = OpIsInf;
-  if(DemangledName == kOCLBuiltinName::IsNan) OC = OpIsNan;
-  if(DemangledName == kOCLBuiltinName::IsNormal) OC = OpIsNormal;
-
-  assert( OC != OpNop && "Invalid OC in visitCallForUnaryIntAsBool");
-
-  BuiltinFuncMangleInfo mangler;
-  AttributeSet AS = CI->getCalledFunction()->getAttributes();
-
-  CallInst* CallInst = 
-    addCallInst(M, getSPIRVFuncName(OC), Type::getInt1Ty(M->getContext()), Args, 
-    &AS, 
-    CI, 
-    &mangler);
-
-  auto Ty = CI->getType();
-  auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-  auto One = getScalarOrVectorConstantInt(Ty, 1, false);
-  auto Sel = SelectInst::Create(CallInst, One, Zero, "");
-    
-  Sel->insertAfter(CallInst);
-  CI->replaceAllUsesWith(Sel);
-  CI->eraseFromParent();
-}
-
-void
-OCL20ToSPIRV::visitCallPrefetch(CallInst* CI, StringRef MangledName, const std::string& DemangledName){
-    AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-    mutateCallInstSPIRV(M, CI, [=](CallInst *, std::vector<Value *> &Args){
-        Args[0] = CI->getOperand(1);
-        Args[1] = CI->getOperand(0);
-        return kOCLBuiltinName::Prefetch;
-    }, &Attrs);
-}
 
 void OCL20ToSPIRV::visitCallGetFence(CallInst *CI, StringRef MangledName,
                                      const std::string &DemangledName) {

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -126,20 +126,7 @@ getExtOp(StringRef OrigName, const std::string &GivenDemangledName) {
   OCLExtOpKind EOC;
   bool Found = OCLExtOpMap::rfind(DemangledName, &EOC);
   if (!Found) {
-    std::string Prefix;
-    switch (LastFuncParamType(OrigName))
-    {
-    case ParamType::UNSIGNED:
-        Prefix = "u_";
-        break;
-    case ParamType::SIGNED:
-        Prefix = "s_";
-        break;
-    case ParamType::FLOAT:
-        Prefix = "f";
-        break;
-    default: assert(0 && "unknown mangling!");
-    }
+    std::string Prefix = isLastFuncParamSigned(OrigName) ? "s_" : "u_";
     Found = OCLExtOpMap::rfind(Prefix + DemangledName, &EOC);
   }
   if (Found)

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -132,8 +132,6 @@ struct OCLBuiltinTransInfo {
 //
 ///////////////////////////////////////////////////////////////////////////////
 namespace kOCLBuiltinName {
-  const static char All[]                       = "all";
-  const static char Any[]                       = "any";
   const static char AsyncWorkGroupCopy[]        = "async_work_group_copy";
   const static char AsyncWorkGroupStridedCopy[] = "async_work_group_strided_copy";
   const static char AtomPrefix[]         = "atom_";
@@ -146,7 +144,6 @@ namespace kOCLBuiltinName {
   const static char AtomicWorkItemFence[] = "atomic_work_item_fence";
   const static char Barrier[]            = "barrier";
   const static char ConvertPrefix[]      = "convert_";
-  const static char Dot[]                = "dot";
   const static char EnqueueKernel[]      = "enqueue_kernel";
   const static char GetFence[]           = "get_fence";
   const static char GetImageArraySize[]  = "get_image_array_size";
@@ -157,7 +154,6 @@ namespace kOCLBuiltinName {
   const static char MemFence[]           = "mem_fence";
   const static char NDRangePrefix[]      = "ndrange_";
   const static char Pipe[]               = "pipe";
-  const static char Prefetch[]           = "prefetch";
   const static char ReadImage[]          = "read_image";
   const static char ReadPipe[]           = "read_pipe";
   const static char RoundingPrefix[]     = "_r";
@@ -179,10 +175,6 @@ namespace kOCLBuiltinName {
   const static char WritePipe[]          = "write_pipe";
   const static char WorkGroupPrefix[]    = "work_group_";
   const static char WorkPrefix[]         = "work_";
-  const static char IsFinite[]           = "isfinite";
-  const static char IsNan[]              = "isnan";
-  const static char IsNormal[]           = "isnormal";
-  const static char IsInf[]              = "isinf";
 }
 
 /// OCL 1.x atomic memory order when translated to 2.0 atomics.

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -478,7 +478,7 @@ void addFnAttr(LLVMContext *Context, CallInst *Call,
     Attribute::AttrKind Attr);
 void saveLLVMModule(Module *M, const std::string &OutputFile);
 std::string mapSPIRVTypeToOCLType(SPIRVType* Ty, bool Signed);
-std::string mapLLVMTypeToOCLType(Type* Ty, bool Signed);
+std::string mapLLVMTypeToOCLType(const Type* Ty, bool Signed);
 SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target);
 
 /// Add decorations to a SPIR-V entry.
@@ -726,6 +726,7 @@ std::string getPostfix(Decoration Dec, unsigned Value = 0);
 /// Get postfix _R{ReturnType} for return type
 /// The returned postfix does not includ "_" at the beginning
 std::string getPostfixForReturnType(CallInst *CI, bool IsSigned = false);
+std::string getPostfixForReturnType(const Type *pRetTy, bool IsSigned = false);
 
 Constant *
 getScalarOrVectorConstantInt(Type *T, uint64_t V, bool isSigned = false);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -478,7 +478,7 @@ void addFnAttr(LLVMContext *Context, CallInst *Call,
     Attribute::AttrKind Attr);
 void saveLLVMModule(Module *M, const std::string &OutputFile);
 std::string mapSPIRVTypeToOCLType(SPIRVType* Ty, bool Signed);
-std::string mapLLVMTypeToOCLType(const Type* Ty, bool Signed);
+std::string mapLLVMTypeToOCLType(Type* Ty, bool Signed);
 SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target);
 
 /// Add decorations to a SPIR-V entry.
@@ -539,8 +539,6 @@ bool isDecoratedSPIRVFunc(const Function *F, std::string *UndecName = nullptr);
 
 /// Get a canonical function name for a SPIR-V op code.
 std::string getSPIRVFuncName(Op OC, StringRef PostFix = "");
-
-std::string getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned = false);
 
 /// Get a canonical function name for a SPIR-V extended instruction
 std::string getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
@@ -728,7 +726,6 @@ std::string getPostfix(Decoration Dec, unsigned Value = 0);
 /// Get postfix _R{ReturnType} for return type
 /// The returned postfix does not includ "_" at the beginning
 std::string getPostfixForReturnType(CallInst *CI, bool IsSigned = false);
-std::string getPostfixForReturnType(const Type *pRetTy, bool IsSigned = false);
 
 Constant *
 getScalarOrVectorConstantInt(Type *T, uint64_t V, bool isSigned = false);
@@ -768,27 +765,9 @@ eraseIfNoUse(Value *V);
 bool
 isMangledTypeUnsigned(char Mangled);
 
-// Check if a mangled type name is signed
-bool
-isMangledTypeSigned(char Mangled);
-
-// Check if a mangled type name is floating point
-bool
-isMangledTypeFP(char Mangled);
-
 // Check if \param I is valid vector size: 2, 3, 4, 8, 16.
 bool
 isValidVectorSize(unsigned I);
-
-enum class ParamType
-{
-    FLOAT    = 0,
-    SIGNED   = 1,
-    UNSIGNED = 2,
-    UNKNOWN  = 3
-};
-
-ParamType LastFuncParamType(const std::string& MangledName);
 
 // Check if the last function parameter is signed
 bool

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -110,14 +110,14 @@ saveLLVMModule(Module *M, const std::string &OutputFile) {
 }
 
 std::string
-mapLLVMTypeToOCLType(const Type* Ty, bool Signed) {
+mapLLVMTypeToOCLType(Type* Ty, bool Signed) {
   if (Ty->isHalfTy())
     return "half";
   if (Ty->isFloatTy())
     return "float";
   if (Ty->isDoubleTy())
     return "double";
-  if (auto* intTy = dyn_cast<IntegerType>(Ty)) {
+  if (IntegerType* intTy = dyn_cast<IntegerType>(Ty)) {
     std::string SignPrefix;
     std::string Stem;
     if (!Signed)
@@ -141,7 +141,7 @@ mapLLVMTypeToOCLType(const Type* Ty, bool Signed) {
     }
     return SignPrefix + Stem;
   }
-  if (auto* vecTy = dyn_cast<VectorType>(Ty)) {
+  if (VectorType* vecTy = dyn_cast<VectorType>(Ty)) {
     Type* eleTy = vecTy->getElementType();
     unsigned size = vecTy->getVectorNumElements();
     std::stringstream ss;
@@ -363,12 +363,6 @@ getSPIRVFuncName(Op OC, StringRef PostFix) {
 }
 
 std::string
-getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned) {
-  return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider
-      + getPostfixForReturnType(pRetTy, false));
-}
-
-std::string
 getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
     StringRef PostFix) {
   std::string ExtOpName;
@@ -420,13 +414,8 @@ getPostfix(Decoration Dec, unsigned Value) {
 
 std::string
 getPostfixForReturnType(CallInst *CI, bool IsSigned) {
-    return getPostfixForReturnType(CI->getType(), IsSigned);
-}
-
-std::string
-getPostfixForReturnType(const Type *pRetTy, bool IsSigned) {
   return std::string(kSPIRVPostfix::Return) +
-        mapLLVMTypeToOCLType(pRetTy, IsSigned);
+        mapLLVMTypeToOCLType(CI->getType(), IsSigned);
 }
 
 Op
@@ -503,23 +492,6 @@ isMangledTypeUnsigned(char Mangled) {
       || Mangled == 'm' /* ulong */;
 }
 
-// Check if a mangled type name is signed
-bool
-isMangledTypeSigned(char Mangled) {
-  return Mangled == 'c' /* char */
-      || Mangled == 'a' /* signed char */
-      || Mangled == 's' /* short */
-      || Mangled == 'i' /* int */
-      || Mangled == 'l' /* long */;
-}
-
-// Check if a mangled type name is floating point
-bool
-isMangledTypeFP(char Mangled) {
-  return Mangled == 'f' /* float */
-      || Mangled == 'd'; /* double */
-}
-
 void
 eraseSubstitutionFromMangledName(std::string& MangledName) {
   auto Len = MangledName.length();
@@ -529,32 +501,16 @@ eraseSubstitutionFromMangledName(std::string& MangledName) {
   }
 }
 
-ParamType LastFuncParamType(const std::string& MangledName)
-{
-  auto Copy = MangledName;
-  eraseSubstitutionFromMangledName(Copy);
-  char Mangled = Copy.back();
-
-  if (isMangledTypeUnsigned(Mangled))
-  {
-      return ParamType::UNSIGNED;
-  }
-  else if (isMangledTypeSigned(Mangled))
-  {
-      return ParamType::SIGNED;
-  }
-  else if (isMangledTypeFP(Mangled))
-  {
-      return ParamType::FLOAT;
-  }
-
-  return ParamType::UNKNOWN;
-}
-
 // Check if the last argument is signed
 bool
 isLastFuncParamSigned(const std::string& MangledName) {
-  return LastFuncParamType(MangledName) == ParamType::SIGNED;
+  auto Copy = MangledName;
+  eraseSubstitutionFromMangledName(Copy);
+  char Mangled = Copy.back();
+  bool Signed = true;
+  if (isMangledTypeUnsigned(Mangled))
+    Signed = false;
+  return Signed;
 }
 
 
@@ -963,8 +919,6 @@ transTypeDesc(Type *Ty, const BuiltinArgTypeMangleInfo &Info) {
   }
   if(auto *IntTy = dyn_cast<IntegerType>(Ty)) {
     switch(IntTy->getBitWidth()) {
-    case 1:
-      return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_BOOL));
     case 8:
       return SPIR::RefParamType(new SPIR::PrimitiveType(Signed?
           SPIR::PRIMITIVE_CHAR:SPIR::PRIMITIVE_UCHAR));

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -110,14 +110,14 @@ saveLLVMModule(Module *M, const std::string &OutputFile) {
 }
 
 std::string
-mapLLVMTypeToOCLType(Type* Ty, bool Signed) {
+mapLLVMTypeToOCLType(const Type* Ty, bool Signed) {
   if (Ty->isHalfTy())
     return "half";
   if (Ty->isFloatTy())
     return "float";
   if (Ty->isDoubleTy())
     return "double";
-  if (IntegerType* intTy = dyn_cast<IntegerType>(Ty)) {
+  if (auto intTy = dyn_cast<IntegerType>(Ty)) {
     std::string SignPrefix;
     std::string Stem;
     if (!Signed)
@@ -141,7 +141,7 @@ mapLLVMTypeToOCLType(Type* Ty, bool Signed) {
     }
     return SignPrefix + Stem;
   }
-  if (VectorType* vecTy = dyn_cast<VectorType>(Ty)) {
+  if (auto vecTy = dyn_cast<VectorType>(Ty)) {
     Type* eleTy = vecTy->getElementType();
     unsigned size = vecTy->getVectorNumElements();
     std::stringstream ss;
@@ -416,6 +416,11 @@ std::string
 getPostfixForReturnType(CallInst *CI, bool IsSigned) {
   return std::string(kSPIRVPostfix::Return) +
         mapLLVMTypeToOCLType(CI->getType(), IsSigned);
+}
+
+std::string getPostfixForReturnType(const Type *pRetTy, bool IsSigned) {
+  return std::string(kSPIRVPostfix::Return) +
+         mapLLVMTypeToOCLType(pRetTy, IsSigned);
 }
 
 Op

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1426,24 +1426,8 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
       auto Cmp = BM->addCmpInst(OC, BBT,
         transValue(CI->getArgOperand(0), BB),
         transValue(CI->getArgOperand(1), BB), BB);
-      SPIRVValue *pZero = nullptr;
-      SPIRVValue *pOne  = nullptr;
-      if (IsVector) {
-        std::vector<SPIRVValue *> BVZero;
-        std::vector<SPIRVValue *> BVOne;
-        for (auto i = 0U; i < ResultTy->getVectorNumElements(); i++) {
-          BVZero.push_back(transValue(
-              ConstantInt::get(ResultTy->getScalarType(), 0), nullptr));
-          BVOne.push_back(transValue(
-              ConstantInt::get(ResultTy->getScalarType(), ~0), nullptr));
-        }
-        pZero = BM->addCompositeConstant(BT, BVZero);
-        pOne = BM->addCompositeConstant(BT, BVOne);
-      } else {
-        pZero = BM->addIntegerConstant(static_cast<SPIRVTypeInt *>(BT), 0);
-        pOne = BM->addIntegerConstant(static_cast<SPIRVTypeInt *>(BT), 1);
-      }
-      return BM->addSelectInst(Cmp, pOne, pZero, BB);
+      auto CastOC = IsVector ? OpSConvert : OpUConvert;
+      return BM->addUnaryInst(CastOC, BT, Cmp, BB);
     } else if (isBinaryOpCode(OC)) {
       assert(CI && CI->getNumArgOperands() == 2 && "Invalid call inst");
       return BM->addBinaryInst(OC, transType(CI->getType()),
@@ -1522,10 +1506,10 @@ addPassesForSPIRV(PassManager &PassMgr) {
   PassMgr.add(createTransOCLMD());
   PassMgr.add(createOCL21ToSPIRV());
   PassMgr.add(createSPIRVLowerOCLBlocks());
+  PassMgr.add(createSPIRVLowerBool());
   PassMgr.add(createOCL20ToSPIRV());
   PassMgr.add(createSPIRVRegularizeLLVM());
   PassMgr.add(createSPIRVLowerConstExpr());
-  PassMgr.add(createSPIRVLowerBool());
 }
 
 bool

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -365,7 +365,6 @@ SPIRVModuleImpl::addLine(SPIRVEntry* E, SPIRVString* FileName,
 // multiple targets.
 void
 SPIRVModuleImpl::optimizeDecorates() {
-
   SPIRVDBG(spvdbgs() << "[optimizeDecorates] begin\n");
   for (auto I = DecorateSet.begin(), E = DecorateSet.end(); I != E;) {
     auto D = *I;
@@ -399,17 +398,11 @@ SPIRVModuleImpl::optimizeDecorates() {
         continue;
       Targets.push_back(E->getTargetId());
     }
-
-    // WordCount is only 16 bits.  We can only have 65535 - FixedWC targtets per group.
-    // For now, just skip using a group if the number of targets to too big
-    if( Targets.size() < 65530 ) {
-      DecorateSet.erase(ER.first, ER.second);
-      auto GD = new SPIRVGroupDecorate(G, Targets);
-      DecGroupVec.push_back(G);
-      GroupDecVec.push_back(GD);
-    }
+    DecorateSet.erase(ER.first, ER.second);
+    auto GD = new SPIRVGroupDecorate(G, Targets);
+    DecGroupVec.push_back(G);
+    GroupDecVec.push_back(GD);
   }
-
 }
 
 SPIRVValue*


### PR DESCRIPTION
This commit is reverted because of the following reasons:
1. it introduces wrong encoding for prefetch instruction
2. there are no regression tests
3. it breaks round-trip conversion to LLVM IR

The plan is gradually merge those fixes from the https://github.com/scottp101/SPIRV-LLVM/commits/khronos/spirv-3.6.1 fork, but they must come with regression tests and preserve round-trip conversion to LLVM IR.
