### PR TITLE
Fix for get_image_array_size().

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -562,6 +562,8 @@ bool isDecoratedSPIRVFunc(const Function *F, std::string *UndecName = nullptr);
 /// Get a canonical function name for a SPIR-V op code.
 std::string getSPIRVFuncName(Op OC, StringRef PostFix = "");
 
+std::string getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned = false);
+
 /// Get a canonical function name for a SPIR-V extended instruction
 std::string getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
     StringRef PostFix = "");

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -364,6 +364,12 @@ getSPIRVFuncName(Op OC, StringRef PostFix) {
 }
 
 std::string
+getSPIRVFuncName(Op OC, const Type *pRetTy, bool IsSigned) {
+  return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider +
+                         getPostfixForReturnType(pRetTy, false));
+}
+
+std::string
 getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
     StringRef PostFix) {
   std::string ExtOpName;
@@ -415,8 +421,7 @@ getPostfix(Decoration Dec, unsigned Value) {
 
 std::string
 getPostfixForReturnType(CallInst *CI, bool IsSigned) {
-  return std::string(kSPIRVPostfix::Return) +
-        mapLLVMTypeToOCLType(CI->getType(), IsSigned);
+  return getPostfixForReturnType(CI->getType(), IsSigned);
 }
 
 std::string getPostfixForReturnType(const Type *pRetTy, bool IsSigned) {

--- a/test/SPIRV/transcoding/OpImageQuerySize.ll
+++ b/test/SPIRV/transcoding/OpImageQuerySize.ll
@@ -3,6 +3,8 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
@@ -19,6 +21,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-DAG: %opencl.image2d_t = type opaque
 ; CHECK-DAG: %opencl.image2d_depth_t = type opaque
 ; CHECK-DAG: %opencl.image2d_array_t = type opaque
+; CHECK-SPIRV: 10 TypeImage [[ArrayTypeID:[0-9]+]] {{[0-9]+}} 0 0 1 0 0 0 0
 ; CHECK-DAG: %opencl.image2d_array_depth_t = type opaque
 ; CHECK-DAG: %opencl.image3d_t = type opaque
 
@@ -44,7 +47,9 @@ target triple = "spir64-unknown-unknown"
 ; CHECK:   insertelement <2 x i32> {{.*}} 1
 
 ; CHECK:   call {{.*}} i64 @_Z20get_image_array_size16ocl_image1darray
-; ATM SPIR-V writer translates get_image1d_array_t into function call
+; CHECK-SPIRV: 3 FunctionParameter [[ArrayTypeID]] [[ArrayVarID:[0-9]+]]
+; CHECK-SPIRV: ImageQuerySizeLod {{[0-9]+}} {{[0-9]+}} [[ArrayVarID]]
+; CHECK-SPIRV-NOT: {{[0-9]*}} ExtInst {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} get_image_array_size
 
 ; Function Attrs: nounwind
 define spir_kernel void @test_image1d(i32 addrspace(1)* nocapture %sizes, %opencl.image1d_t addrspace(1)* %img, %opencl.image1d_buffer_t addrspace(1)* %buffer, %opencl.image1d_array_t addrspace(1)* %array) #0 {


### PR DESCRIPTION
Add return type to overload for OpImageQuerySizeLod and OpImageQuerySize.

Refactor return mangling into function.
