### PR TITLE
[SPIR-V] OpDot accepts vector arguments, so we translate dot(<scalar>…

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -225,13 +225,16 @@ public:
   void visitCallVecLoadStore(CallInst *CI, StringRef MangledName,
       const std::string &DemangledName);
 
-
   /// Transforms get_mem_fence built-in to SPIR-V function and aligns result values with SPIR 1.2.
   /// get_mem_fence(ptr) => __spirv_GenericPtrMemSemantics
   /// GenericPtrMemSemantics valid values are 0x100, 0x200 and 0x300, where is
   /// SPIR 1.2 defines them as 0x1, 0x2 and 0x3, so this function adjusts
   /// GenericPtrMemSemantics results to SPIR 1.2 values.
   void visitCallGetFence(CallInst *CI, StringRef MangledName, const std::string& DemangledName);
+
+  /// Transforms OpDot instructions with a scalar type to a fmul instruction
+  void visitCallDot(CallInst *CI);
+  
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
     I.eraseFromParent();
@@ -443,6 +446,11 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
   }
   if (DemangledName == kOCLBuiltinName::GetFence) {
     visitCallGetFence(&CI, MangledName, DemangledName);
+    return;
+  }
+  if (DemangledName == kOCLBuiltinName::Dot &&
+      !(CI.getOperand(0)->getType()->isVectorTy())) {
+    visitCallDot(&CI);
     return;
   }
   visitCallBuiltinSimple(&CI, MangledName, DemangledName);
@@ -1195,7 +1203,16 @@ void OCL20ToSPIRV::visitCallGetFence(CallInst *CI, StringRef MangledName,
             &Attrs);
 }
 
+void OCL20ToSPIRV::visitCallDot(CallInst *CI) {
+  IRBuilder<> Builder(CI);
+  Value *FMulVal = Builder.CreateFMul(CI->getOperand(0), CI->getOperand(1));
+  CI->replaceAllUsesWith(FMulVal);
+  CI->dropAllReferences();
+  CI->removeFromParent();
 }
+
+}
+
 INITIALIZE_PASS(OCL20ToSPIRV, "cl20tospv", "Transform OCL 2.0 to SPIR-V",
     false, false)
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -146,6 +146,7 @@ namespace kOCLBuiltinName {
   const static char AtomicWorkItemFence[] = "atomic_work_item_fence";
   const static char Barrier[]            = "barrier";
   const static char ConvertPrefix[]      = "convert_";
+  const static char Dot[]                = "dot";
   const static char EnqueueKernel[]      = "enqueue_kernel";
   const static char GetFence[]           = "get_fence";
   const static char GetImageArraySize[]  = "get_image_array_size";

--- a/test/SPIRV/transcoding/OpDot.ll
+++ b/test/SPIRV/transcoding/OpDot.ll
@@ -1,0 +1,45 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: fmul
+
+; CHECK-SPIRV: 5 FMul
+; CHECK-SPIRV-NOT: Dot
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test(float %f) #0 {
+entry:
+  %call = tail call spir_func float @_Z3dotff(float %f, float %f) #2
+  ret void
+}
+
+declare spir_func float @_Z3dotff(float, float) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (float)* @test, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"float"}
+!4 = !{!"kernel_arg_base_type", !"float"}
+!5 = !{!"kernel_arg_type_qual", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
…, <scalar>) to OpFMul.
