### PR TITLE
Fixed wrong return type on IsNan, IsFinite, IsInf and IsNormal.

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -153,6 +153,10 @@ namespace kOCLBuiltinName {
   const static char GetImageDim[]        = "get_image_dim";
   const static char GetImageHeight[]     = "get_image_height";
   const static char GetImageWidth[]      = "get_image_width";
+  const static char IsFinite[]           = "isfinite";
+  const static char IsNan[]              = "isnan";
+  const static char IsNormal[]           = "isnormal";
+  const static char IsInf[]              = "isinf";
   const static char MemFence[]           = "mem_fence";
   const static char NDRangePrefix[]      = "ndrange_";
   const static char Pipe[]               = "pipe";

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -471,6 +471,7 @@ private:
   bool foreachFuncCtlMask(Source, Func);
   llvm::GlobalValue::LinkageTypes transLinkageType(const SPIRVValue* V);
   Instruction *transOCLAllAny(SPIRVInstruction* BI, BasicBlock *BB);
+  Instruction *transOCLRelational(SPIRVInstruction* BI, BasicBlock *BB);
 };
 
 Type *
@@ -1560,6 +1561,13 @@ SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV,
                     transOCLAllAny(static_cast<SPIRVInstruction *>(BV), BB));
 
+  case OpIsFinite :
+  case OpIsInf :
+  case OpIsNan :
+  case OpIsNormal :
+    return mapValue(BV,
+                    transOCLRelational(static_cast<SPIRVInstruction *>(BV), BB));
+
   default: {
     auto OC = BV->getOpCode();
     if (isSPIRVCmpInstTransToLLVMInst(static_cast<SPIRVInstruction*>(BV))) {
@@ -2331,6 +2339,32 @@ Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
              [=](CallInst *NewCI) -> Instruction * {
                return CastInst::CreateTruncOrBitCast(
                    NewCI, Type::getInt1Ty(*Context), "", NewCI->getNextNode());
+             },
+             &Attrs)));
+}
+
+Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I, BasicBlock *BB) {
+  CallInst *CI = cast<CallInst>(transSPIRVBuiltinFromInst(I, BB));
+  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
+  return cast<Instruction>(mapValue(
+      I, mutateCallInstOCL(
+             M, CI,
+             [=](CallInst *, std::vector<Value *> &Args, llvm::Type *&RetTy) {
+               Type *Int32Ty = Type::getInt32Ty(*Context);
+               RetTy = Int32Ty;
+               if (CI->getType()->isVectorTy())
+                 RetTy = VectorType::get(Int32Ty,
+                                         CI->getType()->getVectorNumElements());
+               return CI->getCalledFunction()->getName();
+             },
+             [=](CallInst *NewCI) -> Instruction * {
+               Type *RetTy = Type::getInt1Ty(*Context);
+               if (NewCI->getType()->isVectorTy())
+                 RetTy =
+                     VectorType::get(Type::getInt1Ty(*Context),
+                                     NewCI->getType()->getVectorNumElements());
+               return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",
+                                                     NewCI->getNextNode());
              },
              &Attrs)));
 }

--- a/test/SPIRV/transcoding/relationals.ll
+++ b/test/SPIRV/transcoding/relationals.ll
@@ -1,0 +1,101 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func i32 @_Z8isfinitef(
+; CHECK-LLVM: call spir_func i32 @_Z5isnanf(
+; CHECK-LLVM: call spir_func i32 @_Z5isinff(
+; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
+
+; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(
+; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
+; CHECK-LLVM: call spir_func <2 x i32> @_Z5isinfDv2_f(
+; CHECK-LLVM: call spir_func <2 x i32> @_Z8isnormalDv2_f(
+
+; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
+; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2
+
+; CHECK-SPIRV: 4 IsFinite [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
+
+; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test_scalar(i32 addrspace(1)* nocapture %out, float %f) #0 {
+entry:
+  %call = tail call spir_func i32 @_Z8isfinitef(float %f) #2
+  %call1 = tail call spir_func i32 @_Z5isnanf(float %f) #2
+  %add = add nsw i32 %call1, %call
+  %call2 = tail call spir_func i32 @_Z5isinff(float %f) #2
+  %add3 = add nsw i32 %add, %call2
+  %call4 = tail call spir_func i32 @_Z8isnormalf(float %f) #2
+  %add5 = add nsw i32 %add3, %call4
+  store i32 %add5, i32 addrspace(1)* %out, align 4
+  ret void
+}
+
+declare spir_func i32 @_Z8isfinitef(float) #1
+
+declare spir_func i32 @_Z5isnanf(float) #1
+
+declare spir_func i32 @_Z5isinff(float) #1
+
+declare spir_func i32 @_Z8isnormalf(float) #1
+
+; Function Attrs: nounwind
+define spir_kernel void @test_vector(<2 x i32> addrspace(1)* nocapture %out, <2 x float> %f) #0 {
+entry:
+  %call = tail call spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float> %f) #2
+  %call1 = tail call spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float> %f) #2
+  %add = add <2 x i32> %call, %call1
+  %call2 = tail call spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float> %f) #2
+  %add3 = add <2 x i32> %add, %call2
+  %call4 = tail call spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float> %f) #2
+  %add5 = add <2 x i32> %add3, %call4
+  store <2 x i32> %add5, <2 x i32> addrspace(1)* %out, align 8
+  ret void
+}
+
+declare spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float>) #1
+
+declare spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float>) #1
+
+declare spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float>) #1
+
+declare spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float>) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0, !6}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!9}
+!opencl.ocl.version = !{!10}
+!opencl.used.extensions = !{!11}
+!opencl.used.optional.core.features = !{!11}
+!opencl.compiler.options = !{!11}
+
+!0 = !{void (i32 addrspace(1)*, float)* @test_scalar, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"int*", !"float"}
+!4 = !{!"kernel_arg_base_type", !"int*", !"float"}
+!5 = !{!"kernel_arg_type_qual", !"", !""}
+!6 = !{void (<2 x i32> addrspace(1)*, <2 x float>)* @test_vector, !1, !2, !7, !8, !5}
+!7 = !{!"kernel_arg_type", !"int2*", !"float2"}
+!8 = !{!"kernel_arg_base_type", !"int2*", !"float2"}
+!9 = !{i32 1, i32 2}
+!10 = !{i32 2, i32 0}
+!11 = !{}


### PR DESCRIPTION
OpenCL functions return integer types whereas SPIR-V counterparts return boolean types.
