### PR TITLE
Fix for translation of linkage type for tentative definitions

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -61,7 +61,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 10;
+  const static unsigned short kTranslatorVer = 11;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/test/SPIRV/linkage-types.ll
+++ b/test/SPIRV/linkage-types.ll
@@ -12,6 +12,10 @@ target triple = "spir-unknown-unknown"
 ; SPIRV:  Capability Linkage
 ; SPIRV: EntryPoint 6 [[kern:[0-9]+]] "kern"
 
+@ae = available_externally addrspace(1) global i32 79, align 4
+; SPIRV: Name [[ae:[0-9]+]] "ae"
+; BACK-TO-LLVM: @ae = available_externally addrspace(1) global i32 79, align 4
+
 @i1 = addrspace(1) global i32 1, align 4
 ; SPIRV: Name [[i1:[0-9]+]] "i1"
 ; BACK-TO-LLVM: @i1 = addrspace(1) global i32 1, align 4
@@ -26,8 +30,7 @@ target triple = "spir-unknown-unknown"
 
 @i4 = common addrspace(1) global i32 0, align 4
 ; SPIRV: Name [[i4:[0-9]+]] "i4"
-; BACK-TO-LLVM: @i4 = available_externally addrspace(1) global i32 0, align 4
-; "common" is lost in translation
+; BACK-TO-LLVM: @i4 = common addrspace(1) global i32 0, align 4
 
 @i5 = internal addrspace(1) global i32 0, align 4
 ; SPIRV: Name [[i5:[0-9]+]] "i5"
@@ -74,12 +77,13 @@ target triple = "spir-unknown-unknown"
 ; SPIRV-DAG: Name [[g:[0-9]+]] "g"
 ; SPIRV-DAG: Name [[inline_fun:[0-9]+]] "inline_fun"
 
+; SPIRV-DAG: Decorate [[ae]] LinkageAttributes "ae" Import
 ; SPIRV-DAG: Decorate [[e]] LinkageAttributes "e" Import
 ; SPIRV-DAG: Decorate [[f]] LinkageAttributes "f" Export
 ; SPIRV-DAG: Decorate [[w]] LinkageAttributes "w" Export
 ; SPIRV-DAG: Decorate [[i1]] LinkageAttributes "i1" Export
 ; SPIRV-DAG: Decorate [[i3]] LinkageAttributes "i3" Export
-; SPIRV-DAG: Decorate [[i4]] LinkageAttributes "i4" Import
+; SPIRV-DAG: Decorate [[i4]] LinkageAttributes "i4" Export
 ; SPIRV-DAG: Decorate [[foo]] LinkageAttributes "foo" Import
 ; SPIRV-DAG: Decorate [[inline_fun]] LinkageAttributes "inline_fun" Export
 ; SPIRV-DAG: Decorate [[color_table]] LinkageAttributes "color_table" Export


### PR DESCRIPTION
Tentative definition in C => common linkage type variable in LLVM =>
Export linkage type variable w/o initializer in SPIR-V =>
common linkage type variable in LLVM.
