### PR TITLE
[SPIR-V] Fix for OpGroupAll/OpGroupAny.

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -121,7 +121,9 @@ struct OCLBuiltinTransInfo {
   /// Postprocessor of operands
   std::function<void(std::vector<Value *>&)> PostProc;
   Type* RetTy;              // Return type of the translated function
-  OCLBuiltinTransInfo():RetTy(nullptr){
+  bool isRetSigned;         // When RetTy is int, determines if extensions
+                            // on it should be a sext or zet.
+  OCLBuiltinTransInfo() : RetTy(nullptr), isRetSigned(false) {
     PostProc = [](std::vector<Value *>&){};
   }
 };
@@ -181,6 +183,10 @@ namespace kOCLBuiltinName {
   const static char WorkGroupBarrier[]   = "work_group_barrier";
   const static char WritePipe[]          = "write_pipe";
   const static char WorkGroupPrefix[]    = "work_group_";
+  const static char WorkGroupAll[]       = "work_group_all";
+  const static char WorkGroupAny[]       = "work_group_any";
+  const static char SubGroupAll[]        = "sub_group_all";
+  const static char SubGroupAny[]        = "sub_group_any";
   const static char WorkPrefix[]         = "work_";
 }
 

--- a/test/SPIRV/transcoding/OpGroupAllAny.ll
+++ b/test/SPIRV/transcoding/OpGroupAllAny.ll
@@ -1,0 +1,51 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func i32 @_Z14work_group_alli(
+; CHECK-LLVM: call spir_func i32 @_Z14work_group_anyi(
+
+; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
+; CHECK-SPIRV: 3 ConstantTrue [[BoolTypeID]] [[ConstID:[0-9]+]]
+; CHECK-SPIRV: 5 GroupAll [[BoolTypeID]] {{[0-9]+}} {{[0-9]+}} [[ConstID]]
+; CHECK-SPIRV: 5 GroupAny [[BoolTypeID]] {{[0-9]+}} {{[0-9]+}} [[ConstID]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test(i32 addrspace(1)* nocapture readnone %i) #0 {
+entry:
+  %call = tail call spir_func i32 @_Z14work_group_alli(i32 5) #2
+  %call1 = tail call spir_func i32 @_Z14work_group_anyi(i32 5) #2
+  ret void
+}
+
+declare spir_func i32 @_Z14work_group_alli(i32) #1
+
+declare spir_func i32 @_Z14work_group_anyi(i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (i32 addrspace(1)*)* @test, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_base_type", !"int*"}
+!5 = !{!"kernel_arg_type_qual", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
OpenCL built-in functions work_group_all/work_group_any accept/return 32-bit integers, whereas SPIR-V instructions are working with OpTypeBool.
