### PR TITLE
[SPIR-V] Fixes for built-in functions with vector+scalar arguments.

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -147,9 +147,12 @@ namespace kOCLBuiltinName {
   const static char AtomicInit[]          = "atomic_init";
   const static char AtomicWorkItemFence[] = "atomic_work_item_fence";
   const static char Barrier[]            = "barrier";
+  const static char Clamp[]              = "clamp";
   const static char ConvertPrefix[]      = "convert_";
   const static char Dot[]                = "dot";
   const static char EnqueueKernel[]      = "enqueue_kernel";
+  const static char FMax[]               = "fmax";
+  const static char FMin[]               = "fmin";
   const static char GetFence[]           = "get_fence";
   const static char GetImageArraySize[]  = "get_image_array_size";
   const static char GetImageDepth[]      = "get_image_depth";
@@ -160,7 +163,10 @@ namespace kOCLBuiltinName {
   const static char IsNan[]              = "isnan";
   const static char IsNormal[]           = "isnormal";
   const static char IsInf[]              = "isinf";
+  const static char Max[]                = "max";
   const static char MemFence[]           = "mem_fence";
+  const static char Min[]                = "min";
+  const static char Mix[]                = "mix";
   const static char NDRangePrefix[]      = "ndrange_";
   const static char Pipe[]               = "pipe";
   const static char ReadImage[]          = "read_image";
@@ -168,6 +174,8 @@ namespace kOCLBuiltinName {
   const static char RoundingPrefix[]     = "_r";
   const static char Sampled[]            = "sampled_";
   const static char SampledReadImage[]   = "sampled_read_image";
+  const static char SmoothStep[]         = "smoothstep";
+  const static char Step[]               = "step";
   const static char SubGroupPrefix[]     = "sub_group_";
   const static char SubPrefix[]          = "sub_";
   const static char ToGlobal[]           = "to_global";

--- a/test/SPIRV/transcoding/OpMin.ll
+++ b/test/SPIRV/transcoding/OpMin.ll
@@ -1,0 +1,48 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: 4 TypeInt [[IntTypeID:[0-9]+]] 32 {{[0-9]+}}
+; CHECK-SPIRV: 4 TypeVector [[Int2TypeID:[0-9]+]] [[IntTypeID]] 2
+; CHECK-SPIRV: 6 CompositeInsert [[Int2TypeID]] [[CompositeID:[0-9]+]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 7 VectorShuffle [[Int2TypeID]] [[ShuffleID:[0-9]+]] [[CompositeID]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 7 ExtInst [[Int2TypeID]] {{[0-9]+}} 1 s_min {{[0-9]+}} [[ShuffleID]]
+
+; CHECK-LLVM: call spir_func <2 x i32> @_Z3minDv2_iS_(
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test() #0 {
+entry:
+  %call = tail call spir_func <2 x i32> @_Z3minDv2_ii(<2 x i32> <i32 1, i32 10>, i32 5) #2
+  ret void
+}
+
+declare spir_func <2 x i32> @_Z3minDv2_ii(<2 x i32>, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void ()* @test, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space"}
+!2 = !{!"kernel_arg_access_qual"}
+!3 = !{!"kernel_arg_type"}
+!4 = !{!"kernel_arg_base_type"}
+!5 = !{!"kernel_arg_type_qual"}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
Built-in functions like fmin, fmax, max, min, smoothstep, step, clamp and mix have two flavours of argument types: vector+vector and vector+scalar.
SPIR-V has only one version (vector+vector).
We fix translation by converting scalar argument to vector.
