### PR TITLE
[SPIR-V] Fixed translation of signbit relational built-in function.

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -452,7 +452,8 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
   if (DemangledName == kOCLBuiltinName::IsFinite ||
       DemangledName == kOCLBuiltinName::IsInf ||
       DemangledName == kOCLBuiltinName::IsNan ||
-      DemangledName == kOCLBuiltinName::IsNormal) {
+      DemangledName == kOCLBuiltinName::IsNormal ||
+      DemangledName == kOCLBuiltinName::Signbit) {
     visitCallRelational(&CI, DemangledName);
     return;
   }

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -174,6 +174,7 @@ namespace kOCLBuiltinName {
   const static char RoundingPrefix[]     = "_r";
   const static char Sampled[]            = "sampled_";
   const static char SampledReadImage[]   = "sampled_read_image";
+  const static char Signbit[]            = "signbit";
   const static char SmoothStep[]         = "smoothstep";
   const static char Step[]               = "step";
   const static char SubGroupPrefix[]     = "sub_group_";

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1597,6 +1597,7 @@ SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpIsInf :
   case OpIsNan :
   case OpIsNormal :
+  case OpSignBitSet :
     return mapValue(BV,
                     transOCLRelational(static_cast<SPIRVInstruction *>(BV), BB));
 

--- a/test/SPIRV/transcoding/relationals.ll
+++ b/test/SPIRV/transcoding/relationals.ll
@@ -9,6 +9,7 @@
 ; CHECK-LLVM: call spir_func i32 @_Z5isnanf(
 ; CHECK-LLVM: call spir_func i32 @_Z5isinff(
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
+; CHECK-LLVM: call spir_func i32 @_Z7signbitf(
 
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
@@ -22,6 +23,7 @@
 ; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
+; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
@@ -41,7 +43,9 @@ entry:
   %add3 = add nsw i32 %add, %call2
   %call4 = tail call spir_func i32 @_Z8isnormalf(float %f) #2
   %add5 = add nsw i32 %add3, %call4
-  store i32 %add5, i32 addrspace(1)* %out, align 4
+  %call6 = tail call spir_func i32 @_Z7signbitf(float %f) #2
+  %add7 = add nsw i32 %add5, %call6
+  store i32 %add7, i32 addrspace(1)* %out, align 4
   ret void
 }
 
@@ -52,6 +56,8 @@ declare spir_func i32 @_Z5isnanf(float) #1
 declare spir_func i32 @_Z5isinff(float) #1
 
 declare spir_func i32 @_Z8isnormalf(float) #1
+
+declare spir_func i32 @_Z7signbitf(float) #1
 
 ; Function Attrs: nounwind
 define spir_kernel void @test_vector(<2 x i32> addrspace(1)* nocapture %out, <2 x float> %f) #0 {


### PR DESCRIPTION
Map 'int' return data type of signbit built-in function to OpTypeBool return type of OpSignBitSet SPIR-V instruction.
