### PR TITLE
Update SPIRVRepresentationInLLVM.rst

### DIFF
--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -115,6 +115,15 @@ where
 
  * {ConversionOpCodeName} = ConvertFToU|ConvertFToS|ConvertUToF|ConvertUToS|UConvert|SConvert|FConvert|SatConvertSToU|SatConvertUToS
 
+SPIR-V Builtin Reinterpret / Bitcast Function Names
+---------------------------------------------------
+
+The unmangled names of SPIR-V builtin reinterpret / bitcast functions follow the convention:
+
+.. code-block:: c
+
+  __spirv_{BitcastOpCodeName}_R{ReturnType}
+
 SPIR-V Builtin ImageSample Function Names
 ----------------------------------------
 


### PR DESCRIPTION
There is missing naming convention for OpBitcast when used to reinterpret / bitcast between scalar and vector types (as_type / as_typen in OpenCL C / C++). The LLVM representation should have return type encoded in name.
