### PR TITLE
[SPIRV] Support SPIR-V type names for pipe and image types in LLVM to SPIR-V …

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -39,6 +39,7 @@
 
 #include "SPIRVInternal.h"
 #include "OCLUtil.h"
+#include "OCLTypeToSPIRV.h"
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/InstVisitor.h"
@@ -75,6 +76,11 @@ public:
     initializeOCL20ToSPIRVPass(*PassRegistry::getPassRegistry());
   }
   virtual bool runOnModule(Module &M);
+
+  void getAnalysisUsage(AnalysisUsage &AU) const {
+    AU.addRequired<OCLTypeToSPIRV>();
+  }
+
   virtual void visitCallInst(CallInst &CI);
 
   /// Transform barrier/work_group_barrier to __spirv_ControlBarrier.
@@ -989,7 +995,10 @@ void OCL20ToSPIRV::visitCallReadImageWithSampler(
   mutateCallInstSPIRV(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args, Type *&Ret) {
-        auto SampledImgTy = getSPIRVSampledImageType(M, Args[0]->getType());
+        auto SampledImgTy = getSPIRVTypeByChangeBaseTypeName(M,
+            getAnalysis<OCLTypeToSPIRV>().getAdaptedType(Args[0]),
+            kSPIRVTypeName::Image,
+            kSPIRVTypeName::SampledImg);
         Value *SampledImgArgs[] = {Args[0], Args[1]};
         auto SampledImg = addCallInstSPIRV(
             M, getSPIRVFuncName(OpSampledImage), SampledImgTy, SampledImgArgs,
@@ -1383,7 +1392,10 @@ void OCL20ToSPIRV::visitCallScalToVec(CallInst *CI, StringRef MangledName,
 }
 }
 
-INITIALIZE_PASS(OCL20ToSPIRV, "cl20tospv", "Transform OCL 2.0 to SPIR-V",
+INITIALIZE_PASS_BEGIN(OCL20ToSPIRV, "cl20tospv", "Transform OCL 2.0 to SPIR-V",
+    false, false)
+INITIALIZE_PASS_DEPENDENCY(OCLTypeToSPIRV)
+INITIALIZE_PASS_END(OCL20ToSPIRV, "cl20tospv", "Transform OCL 2.0 to SPIR-V",
     false, false)
 
 ModulePass *llvm::createOCL20ToSPIRV() {

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -56,10 +56,11 @@ public:
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;
   virtual bool runOnModule(Module &M);
 
-  /// \return Adapted function type based on kernel argument metadata.
-  /// e.g. for a function with argument of read only opencl.image_2d_t* type
+  /// \return Adapted type based on kernel argument metadata. If \p V is
+  ///   a function, returns function type.
+  /// E.g. for a function with argument of read only opencl.image_2d_t* type
   /// returns a function with argument of type opencl.image2d_t.read_only*.
-  FunctionType *getAdaptedFunctionType(Function *);
+  Type *getAdaptedType(Value *V);
 
   static char ID;
 private:

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -259,7 +259,6 @@ typedef SPIRVMap<SPIRVExtInstSetKind, std::string, SPIRVExtSetShortName>
 #define OCL_TYPE_NAME_SAMPLER_T             "sampler_t"
 #define SPIR_TYPE_NAME_EVENT_T              "opencl.event_t"
 #define SPIR_TYPE_NAME_CLK_EVENT_T          "opencl.clk_event_t"
-#define SPIR_TYPE_NAME_PIPE_T               "opencl.pipe_t"
 #define SPIR_TYPE_NAME_BLOCK_T              "opencl.block"
 #define SPIR_INTRINSIC_BLOCK_BIND           "spir_block_bind"
 #define SPIR_INTRINSIC_GET_BLOCK_INVOKE     "spir_get_block_invoke"
@@ -272,14 +271,20 @@ namespace kLLVMTypeName {
 }
 
 namespace kSPIRVTypeName {
-  const static char Delimiter   = '.';
-  const static char SampledImg[] = "spirv.sampled_image_t";
+  const static char Delimiter        = '.';
+  const static char Image[]          = "Image";
+  const static char Pipe[]           = "Pipe";
+  const static char PostfixDelim     = '_';
+  const static char Prefix[]         = "spirv";
+  const static char PrefixAndDelim[] = "spirv.";
+  const static char SampledImg[]     = "SampledImage";
 }
 
 namespace kSPR2TypeName {
   const static char Delimiter   = '.';
   const static char OCLPrefix[]   = "opencl.";
   const static char ImagePrefix[] = "opencl.image";
+  const static char Pipe[]        = "opencl.pipe_t";
   const static char Sampler[]     = "opencl.sampler_t";
   const static char Event[]       = "opencl.event_t";
 }
@@ -774,8 +779,24 @@ getScalarOrArray(Value *V, unsigned Size, Instruction *Pos);
 void
 dumpUsers(Value* V, StringRef Prompt = "");
 
+/// Get SPIR-V type name as spirv.BaseTyName.Postfixes.
+std::string
+getSPIRVTypeName(StringRef BaseTyName, StringRef Postfixes = "");
+
+/// Get SPIR-V type by changing the type name from spirv.OldName.Postfixes
+/// to spirv.NewName.Postfixes.
 Type *
-getSPIRVSampledImageType(Module *M, Type *ImageType);
+getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
+    StringRef NewName);
+
+/// Get the postfixes of SPIR-V image type name as in spirv.Image.postfixes.
+std::string
+getSPIRVImageTypePostfixes(SPIRVTypeImageDescriptor Desc,
+    SPIRVAccessQualifierKind Acc);
+
+/// Map OpenCL opaque type name to SPIR-V type name.
+std::string
+mapOCLTypeNameToSPIRV(StringRef Name, StringRef Acc = "");
 
 bool
 eraseUselessFunctions(Module *M);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -628,14 +628,14 @@ SPIRVToLLVM::transOCLImageTypeName(SPIRV::SPIRVTypeImage* ST) {
 
 std::string
 SPIRVToLLVM::transOCLSampledImageTypeName(SPIRV::SPIRVTypeSampledImage* ST) {
-  return std::string(kSPIRVTypeName::SampledImg)
-       + kSPR2TypeName::Delimiter
-       + rmap<std::string>(ST->getImageType()->getDescriptor());
+  return getSPIRVTypeName(kSPIRVTypeName::SampledImg,
+    getSPIRVImageTypePostfixes(ST->getImageType()->getDescriptor(),
+      ST->getImageType()->getAccessQualifier()));
 }
 
 std::string
 SPIRVToLLVM::transOCLPipeTypeName(SPIRV::SPIRVTypePipe* PT) {
-  return SPIR_TYPE_NAME_PIPE_T;
+  return kSPR2TypeName::Pipe;
 }
 
 Type *

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -380,6 +380,30 @@ LLVMToSPIRV::isBuiltinTransToExtInst(Function *F,
   return true;
 }
 
+/// Decode SPIR-V type name in the format spirv.{TypeName}._{Postfixes}
+/// where Postfixes are integers separated by underscores.
+/// \return TypeName.
+/// \param Ops contains the integers decoded from postfixes.
+static std::string
+ decodeSPIRVTypeName(StringRef Name,
+    SmallVectorImpl<unsigned>& Ops) {
+  SmallVector<StringRef, 4> SubStrs;
+  const char Delim[] = { kSPIRVTypeName::Delimiter, 0 };
+  Name.split(SubStrs, Delim, -1, true);
+  assert(SubStrs.size() >= 2 && "Invalid SPIRV type name");
+  assert(SubStrs[0] == kSPIRVTypeName::Prefix && "Invalid prefix");
+  assert((SubStrs.size() == 2 || !SubStrs[2].empty()) && "Invalid postfix");
+
+  if (SubStrs.size() > 2) {
+    const char PostDelim[] = { kSPIRVTypeName::PostfixDelim, 0 };
+    SmallVector<StringRef, 4> Postfixes;
+    SubStrs[2].split(Postfixes, PostDelim, -1, true);
+    assert(Postfixes.size() > 1 && Postfixes[0].empty() && "Invalid postfix");
+    for (unsigned I = 1, E = Postfixes.size(); I != E; ++I)
+      Ops.push_back(std::stoi(Postfixes[I]));
+  }
+  return SubStrs[1].str();
+}
 
 SPIRVType *
 LLVMToSPIRV::transType(Type *T) {
@@ -415,7 +439,13 @@ LLVMToSPIRV::transType(Type *T) {
         STName = kSPR2TypeName::Event;
         ST->setName(STName);
       }
-      if (STName.find(SPIR_TYPE_NAME_PIPE_T) == 0) {
+      assert (!STName.startswith(kSPR2TypeName::Pipe) &&
+              "OpenCL type names should be translated to SPIR-V type names");
+      // ToDo: For SPIR1.2/2.0 there may still be load/store or bitcast
+      // instructions using opencl.* type names. We need to handle these
+      // type names until they are all mapped or FE generates SPIR-V type
+      // names.
+      if (STName.find(kSPR2TypeName::Pipe) == 0) {
         assert(AddrSpc == SPIRAS_Global);
         SmallVector<StringRef, 4> SubStrs;
         const char Delims[] = {kSPR2TypeName::Delimiter, 0};
@@ -450,27 +480,39 @@ LLVMToSPIRV::transType(Type *T) {
       } else if (STName == kSPR2TypeName::Sampler) {
         assert(AddrSpc == SPIRAS_Global);
         return mapType(T, BM->addSamplerType());
-      } else if (STName.find(kSPIRVTypeName::SampledImg) == 0) {
-        SmallVector<StringRef, 4> SubStrs;
-        const char Delims[] = {kSPR2TypeName::Delimiter, 0};
-        STName.split(SubStrs, Delims);
-        std::string ImgTyName = kSPR2TypeName::OCLPrefix;
-        ImgTyName += SubStrs[2];
-        if (SubStrs.size() > 3) {
-          ImgTyName += kSPR2TypeName::Delimiter;
-          ImgTyName += SubStrs[3].str();
-        }
-        return mapType(T, BM->addSampledImageType(
-            static_cast<SPIRVTypeImage *>(
-                transType(getOrCreateOpaquePtrType(M, ImgTyName)))));
-      }
-      else if (BuiltinOpaqueGenericTypeOpCodeMap::find(STName, &OpCode)) {
+      } else if (STName.startswith(kSPIRVTypeName::PrefixAndDelim)) {
+          SmallVector<unsigned, 4> Ops;
+          auto TN = decodeSPIRVTypeName(STName, Ops);
+          if (TN == kSPIRVTypeName::Pipe) {
+            assert(AddrSpc == SPIRAS_Global);
+            assert(Ops.size() == 1 && "Invalid pipe type ops");
+            auto PipeT = BM->addPipeType();
+            PipeT->setPipeAcessQualifier(static_cast<spv::AccessQualifier>(
+              Ops[0]));
+            return mapType(T, PipeT);
+          } else if (TN == kSPIRVTypeName::Image) {
+            assert(AddrSpc == SPIRAS_Global);
+            auto VoidT = transType(Type::getVoidTy(*Ctx));
+            SPIRVTypeImageDescriptor Desc(static_cast<SPIRVImageDimKind>(Ops[0]),
+                Ops[1], Ops[2], Ops[3], Ops[4], Ops[5]);
+            return mapType(T, BM->addImageType(VoidT, Desc,
+                           static_cast<spv::AccessQualifier>(Ops[6])));
+          } else if (TN == kSPIRVTypeName::SampledImg) {
+            return mapType(T, BM->addSampledImageType(
+                static_cast<SPIRVTypeImage *>(
+                    transType(getSPIRVTypeByChangeBaseTypeName(M,
+                        T, kSPIRVTypeName::SampledImg,
+                        kSPIRVTypeName::Image)))));
+          } else {
+            // ToDo: translate other SPIRV types.
+            assert(0 && "Not implemented");
+          }
+      } else if (BuiltinOpaqueGenericTypeOpCodeMap::find(STName, &OpCode)) {
         if (OpCode == OpTypePipe) {
           return mapType(T, BM->addPipeType());
         }
         return mapType(T, BM->addOpaqueGenericType(OpCode));
-      }
-      else if (isPointerToOpaqueStructType(T)) {
+      } else if (isPointerToOpaqueStructType(T)) {
         return mapType(T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
           static_cast<SPIRAddressSpace>(AddrSpc)),
           transType(ET)));
@@ -493,7 +535,7 @@ LLVMToSPIRV::transType(Type *T) {
 
   if (T->isStructTy() && !T->isSized()) {
     auto ST = dyn_cast<StructType>(T);
-    assert(!ST->getName().startswith(SPIR_TYPE_NAME_PIPE_T));
+    assert(!ST->getName().startswith(kSPR2TypeName::Pipe));
     assert(!ST->getName().startswith(kSPR2TypeName::ImagePrefix));
     return mapType(T, BM->addOpaqueType(T->getStructName()));
   }
@@ -528,7 +570,7 @@ LLVMToSPIRV::transFunctionDecl(Function *F) {
     return static_cast<SPIRVFunction *>(BF);
 
   SPIRVTypeFunction *BFT = static_cast<SPIRVTypeFunction *>(transType(
-      getAnalysis<OCLTypeToSPIRV>().getAdaptedFunctionType(F)));
+      getAnalysis<OCLTypeToSPIRV>().getAdaptedType(F)));
   SPIRVFunction *BF = static_cast<SPIRVFunction *>(mapValue(F,
       BM->addFunction(BFT)));
   BF->setFunctionControlMask(transFunctionControlMask(F));
@@ -1508,12 +1550,14 @@ LLVMToSPIRV::transLinkageType(const GlobalValue* GV) {
     return SPIRVLinkageTypeKind::LinkageTypeInternal;
   return SPIRVLinkageTypeKind::LinkageTypeExport;
 }
-
 } // end of SPIRV namespace
 
 char LLVMToSPIRV::ID = 0;
 
-INITIALIZE_PASS(LLVMToSPIRV, "llvmtospv", "Translate LLVM to SPIR-V",
+INITIALIZE_PASS_BEGIN(LLVMToSPIRV, "llvmtospv", "Translate LLVM to SPIR-V",
+    false, false)
+INITIALIZE_PASS_DEPENDENCY(OCLTypeToSPIRV)
+INITIALIZE_PASS_END(LLVMToSPIRV, "llvmtospv", "Translate LLVM to SPIR-V",
     false, false)
 
 ModulePass *llvm::createLLVMToSPIRV(SPIRVModule *SMod) {
@@ -1527,6 +1571,7 @@ addPassesForSPIRV(PassManager &PassMgr) {
   PassMgr.add(createTransOCLMD());
   PassMgr.add(createOCL21ToSPIRV());
   PassMgr.add(createSPIRVLowerOCLBlocks());
+  PassMgr.add(createOCLTypeToSPIRV());
   PassMgr.add(createOCL20ToSPIRV());
   PassMgr.add(createSPIRVRegularizeLLVM());
   PassMgr.add(createSPIRVLowerConstExpr());
@@ -1538,7 +1583,6 @@ llvm::WriteSPIRV(Module *M, llvm::raw_ostream &OS, std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
   PassManager PassMgr;
   addPassesForSPIRV(PassMgr);
-  PassMgr.add(createOCLTypeToSPIRV());
   PassMgr.add(createLLVMToSPIRV(BM.get()));
   PassMgr.run(*M);
 

--- a/test/SPIRV/transcoding/cl-types.ll
+++ b/test/SPIRV/transcoding/cl-types.ll
@@ -1,0 +1,120 @@
+;; Test CL opaque types
+;;
+;; // cl-types.cl
+;; // CL source code for generating LLVM IR.
+;; // Command for compilation:
+;; //  clang -cc1 -x cl -cl-std=CL2.0 -triple spir-unknonw-unknown -emit-llvm cl-types.cl
+;; void kernel foo(
+;;  read_only pipe int a,
+;;  write_only pipe int b,
+;;  read_only image1d_t c1,
+;;  read_only image2d_t d1,
+;;  read_only image3d_t e1,
+;;  read_only image2d_array_t f1,
+;;  read_only image1d_buffer_t g1,
+;;  write_only image1d_t c2,
+;;  read_write image2d_t d3
+;; ){
+;; }
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
+; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: 2 TypeVoid [[VOID:[0-9]+]]
+; CHECK-SPIRV-DAG: 3 TypePipe [[PIPE_RD:[0-9]+]] 0
+; CHECK-SPIRV-DAG: 3 TypePipe [[PIPE_WR:[0-9]+]] 1
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1D_RD:[0-9]+]] [[VOID]] 0 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2D_RD:[0-9]+]] [[VOID]] 1 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG3D_RD:[0-9]+]] [[VOID]] 2 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2DA_RD:[0-9]+]] [[VOID]] 1 0 1 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1DB_RD:[0-9]+]] [[VOID]] 5 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1D_WR:[0-9]+]] [[VOID]] 0 0 0 0 0 0 1
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2D_RW:[0-9]+]] [[VOID]] 1 0 0 0 0 0 2
+
+; CHECK-SPIRV: 3 FunctionParameter [[PIPE_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[PIPE_WR]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG3D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2DA_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1DB_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1D_WR]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2D_RW]] {{[0-9]+}}
+
+; ModuleID = 'cl-types.cl'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LLVM-DAG: %opencl.pipe_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image3d_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image2d_array_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image1d_buffer_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image1d_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image2d_t = type opaque
+
+%opencl.pipe_t = type opaque
+%opencl.image3d_t = type opaque
+%opencl.image2d_array_t = type opaque
+%opencl.image1d_buffer_t = type opaque
+%opencl.image1d_t = type opaque
+%opencl.image2d_t = type opaque
+
+; CHECK-LLVM: define spir_kernel void @foo(
+; CHECK-LLVM:   %opencl.pipe_t addrspace(1)* nocapture %a,
+; CHECK-LLVM:   %opencl.pipe_t addrspace(1)* nocapture %b,
+; CHECK-LLVM:   %opencl.image1d_t addrspace(1)* nocapture %c1,
+; CHECK-LLVM:   %opencl.image2d_t addrspace(1)* nocapture %d1,
+; CHECK-LLVM:   %opencl.image3d_t addrspace(1)* nocapture %e1,
+; CHECK-LLVM:   %opencl.image2d_array_t addrspace(1)* nocapture %f1,
+; CHECK-LLVM:   %opencl.image1d_buffer_t addrspace(1)* nocapture %g1,
+; CHECK-LLVM:   %opencl.image1d_t addrspace(1)* nocapture %c2,
+; CHECK-LLVM:   %opencl.image2d_t addrspace(1)* nocapture %d3)
+  
+; Function Attrs: nounwind readnone
+define spir_kernel void @foo(
+  %opencl.pipe_t addrspace(1)* nocapture %a,
+  %opencl.pipe_t addrspace(1)* nocapture %b,
+  %opencl.image1d_t addrspace(1)* nocapture %c1,
+  %opencl.image2d_t addrspace(1)* nocapture %d1,
+  %opencl.image3d_t addrspace(1)* nocapture %e1,
+  %opencl.image2d_array_t addrspace(1)* nocapture %f1,
+  %opencl.image1d_buffer_t addrspace(1)* nocapture %g1,
+  %opencl.image1d_t addrspace(1)* nocapture %c2,
+  %opencl.image2d_t addrspace(1)* nocapture %d3) #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!9}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!10}
+
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_access_qual", !"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_type", !"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_base_type", !"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
+
+!0 = !{void (%opencl.pipe_t addrspace(1)*, %opencl.pipe_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*, %opencl.image3d_t addrspace(1)*, %opencl.image2d_array_t addrspace(1)*, %opencl.image1d_buffer_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*)* @foo, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write"}
+!3 = !{!"kernel_arg_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+!4 = !{!"kernel_arg_base_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+!5 = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}
+!9 = !{!"cl_images"}
+!10 = !{!"clang version 3.6.1 "}

--- a/test/SPIRV/transcoding/spirv-types.ll
+++ b/test/SPIRV/transcoding/spirv-types.ll
@@ -1,0 +1,106 @@
+;; Test SPIR-V opaque types
+;;
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
+; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: 2 TypeVoid [[VOID:[0-9]+]]
+; CHECK-SPIRV-DAG: 3 TypePipe [[PIPE_RD:[0-9]+]] 0
+; CHECK-SPIRV-DAG: 3 TypePipe [[PIPE_WR:[0-9]+]] 1
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1D_RD:[0-9]+]] [[VOID]] 0 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2D_RD:[0-9]+]] [[VOID]] 1 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG3D_RD:[0-9]+]] [[VOID]] 2 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2DA_RD:[0-9]+]] [[VOID]] 1 0 1 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1DB_RD:[0-9]+]] [[VOID]] 5 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG1D_WR:[0-9]+]] [[VOID]] 0 0 0 0 0 0 1
+; CHECK-SPIRV-DAG: 10 TypeImage [[IMG2D_RW:[0-9]+]] [[VOID]] 1 0 0 0 0 0 2
+
+; CHECK-SPIRV: 3 FunctionParameter [[PIPE_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[PIPE_WR]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG3D_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2DA_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1DB_RD]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG1D_WR]] {{[0-9]+}}
+; CHECK-SPIRV: 3 FunctionParameter [[IMG2D_RW]] {{[0-9]+}}
+
+; ModuleID = 'cl-types.cl'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LLVM-DAG: %opencl.pipe_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image3d_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image2d_array_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image1d_buffer_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image1d_t = type opaque
+; CHECK-LLVM-DAG: %opencl.image2d_t = type opaque
+
+%spirv.Pipe._0 = type opaque ; read_only pipe
+%spirv.Pipe._1 = type opaque ; write_only pipe
+%spirv.Image._0_0_0_0_0_0_0 = type opaque ; read_only image1d_t
+%spirv.Image._1_0_0_0_0_0_0 = type opaque ; read_only image2d_t 
+%spirv.Image._2_0_0_0_0_0_0 = type opaque ; read_only image3d_t
+%spirv.Image._1_0_1_0_0_0_0 = type opaque ; read_only image2d_array_t
+%spirv.Image._5_0_0_0_0_0_0 = type opaque ; read_only image1d_buffer_t
+%spirv.Image._0_0_0_0_0_0_1 = type opaque ; write_only image1d_t
+%spirv.Image._1_0_0_0_0_0_2 = type opaque ; read_write image2d_t
+
+; CHECK-LLVM: define spir_kernel void @foo(
+; CHECK-LLVM:   %opencl.pipe_t addrspace(1)* nocapture %a,
+; CHECK-LLVM:   %opencl.pipe_t addrspace(1)* nocapture %b,
+; CHECK-LLVM:   %opencl.image1d_t addrspace(1)* nocapture %c1,
+; CHECK-LLVM:   %opencl.image2d_t addrspace(1)* nocapture %d1,
+; CHECK-LLVM:   %opencl.image3d_t addrspace(1)* nocapture %e1,
+; CHECK-LLVM:   %opencl.image2d_array_t addrspace(1)* nocapture %f1,
+; CHECK-LLVM:   %opencl.image1d_buffer_t addrspace(1)* nocapture %g1,
+; CHECK-LLVM:   %opencl.image1d_t addrspace(1)* nocapture %c2,
+; CHECK-LLVM:   %opencl.image2d_t addrspace(1)* nocapture %d3)
+  
+; Function Attrs: nounwind readnone
+define spir_kernel void @foo(
+  %spirv.Pipe._0 addrspace(1)* nocapture %a,
+  %spirv.Pipe._1 addrspace(1)* nocapture %b,
+  %spirv.Image._0_0_0_0_0_0_0 addrspace(1)* nocapture %c1,
+  %spirv.Image._1_0_0_0_0_0_0 addrspace(1)* nocapture %d1,
+  %spirv.Image._2_0_0_0_0_0_0 addrspace(1)* nocapture %e1,
+  %spirv.Image._1_0_1_0_0_0_0 addrspace(1)* nocapture %f1,
+  %spirv.Image._5_0_0_0_0_0_0 addrspace(1)* nocapture %g1,
+  %spirv.Image._0_0_0_0_0_0_1 addrspace(1)* nocapture %c2,
+  %spirv.Image._1_0_0_0_0_0_2 addrspace(1)* nocapture %d3) #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!9}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!10}
+
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_access_qual", !"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_type", !"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_base_type", !"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+; CHECK-LLVM-DAG: {{![0-9]+}} = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
+
+!0 = !{void (%spirv.Pipe._0 addrspace(1)*, %spirv.Pipe._1 addrspace(1)*, %spirv.Image._0_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._1_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._2_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._1_0_1_0_0_0_0 addrspace(1)*, %spirv.Image._5_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._0_0_0_0_0_0_1 addrspace(1)*, %spirv.Image._1_0_0_0_0_0_2 addrspace(1)*)* @foo, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write"}
+!3 = !{!"kernel_arg_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+!4 = !{!"kernel_arg_base_type", !"int", !"int", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
+!5 = !{!"kernel_arg_type_qual", !"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}
+!9 = !{!"cl_images"}
+!10 = !{!"clang version 3.6.1 "}


### PR DESCRIPTION
…translator. Map OpenCL image and pipe type names to SPIR-V type names in OCLTypeToSPIRV.
