### PR TITLE
[SPIR-V] Minor refactoring.

### DIFF
--- a/lib/SPIRV/OCL20To12.cpp
+++ b/lib/SPIRV/OCL20To12.cpp
@@ -80,7 +80,7 @@ char OCL20To12::ID = 0;
 bool
 OCL20To12::runOnModule(Module& Module) {
   M = &Module;
-  if (getOCLVersion(M) >= 20)
+  if (getOCLVersion(M) >= kOCLVer::CL20)
     return false;
 
   Ctx = &M->getContext();
@@ -105,7 +105,7 @@ OCL20To12::visitCallInst(CallInst& CI) {
 
   auto MangledName = F->getName();
   std::string DemangledName;
-  if (!oclIsBuiltin(MangledName, 20, &DemangledName))
+  if (!oclIsBuiltin(MangledName, &DemangledName))
     return;
   DEBUG(dbgs() << "DemangledName = " << DemangledName.c_str() << '\n');
 

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -362,7 +362,7 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
 
   auto MangledName = F->getName();
   std::string DemangledName;
-  if (!oclIsBuiltin(MangledName, 20, &DemangledName))
+  if (!oclIsBuiltin(MangledName, &DemangledName))
     return;
   DEBUG(dbgs() << "DemangledName: " << DemangledName << '\n');
   if (DemangledName.find(kOCLBuiltinName::NDRangePrefix) == 0) {
@@ -1148,7 +1148,7 @@ void OCL20ToSPIRV::transWorkItemBuiltinsToVariables() {
   std::vector<Function *> WorkList;
   for (auto I = M->begin(), E = M->end(); I != E; ++I) {
     std::string DemangledName;
-    if (!oclIsBuiltin(I->getName(), 20, &DemangledName))
+    if (!oclIsBuiltin(I->getName(), &DemangledName))
       continue;
     DEBUG(dbgs() << "Function demangled name: " << DemangledName << '\n');
     std::string BuiltinVarName;

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -138,7 +138,7 @@ OCL21ToSPIRV::visitCallInst(CallInst& CI) {
 
   auto MangledName = F->getName();
   std::string DemangledName;
-  if (!oclIsBuiltin(MangledName, CLVer, &DemangledName, true))
+  if (!oclIsBuiltin(MangledName, &DemangledName, true))
     return;
   DEBUG(dbgs() << "DemangledName:" << DemangledName << '\n');
   StringRef Ref(DemangledName);
@@ -178,7 +178,7 @@ void OCL21ToSPIRV::visitCallDecorate(CallInst* CI,
   auto F = Target->getCalledFunction();
   auto Name = F->getName().str();
   std::string DemangledName;
-  oclIsBuiltin(Name, CLVer, &DemangledName);
+  oclIsBuiltin(Name, &DemangledName);
   BuiltinFuncMangleInfo Info;
   F->setName(mangleBuiltin(DemangledName + kSPIRVPostfix::Divider +
       getPostfix(getArgAsDecoration(CI, 1), getArgAsInt(CI, 2)),

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -230,12 +230,11 @@ OCLTypeToSPIRV::getArgBaseTypeMetadata(Function *F) {
 
 // Handle functions with sampler arguments that don't get called by
 // a kernel function.
-void OCLTypeToSPIRV::adaptArgumentsBySamplerUse(Module &M)
-{
-  SmallPtrSet<Function*, 5> Processed;
+void OCLTypeToSPIRV::adaptArgumentsBySamplerUse(Module &M) {
+  SmallPtrSet<Function *, 5> Processed;
 
-  std::function<void(Function*, unsigned)> TraceArg = [&](Function *F,
-                                                          unsigned Idx) {
+  std::function<void(Function *, unsigned)> TraceArg = [&](Function *F,
+                                                           unsigned Idx) {
     // If we have cycles in the call graph in the future, bail out
     // if we've already processed this function.
     if (Processed.insert(F).second == false)
@@ -264,7 +263,7 @@ void OCLTypeToSPIRV::adaptArgumentsBySamplerUse(Module &M)
       continue;
     auto MangledName = F.getName();
     std::string DemangledName;
-    if (!oclIsBuiltin(MangledName, 12, &DemangledName, false))
+    if (!oclIsBuiltin(MangledName, &DemangledName, false))
       continue;
     if (DemangledName.find(kSPIRVName::SampledImage) == std::string::npos)
       continue;

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -119,8 +119,7 @@ WorkGroupBarrierLiterals getWorkGroupBarrierLiterals(CallInst* CI){
 unsigned
 getExtOp(StringRef OrigName, const std::string &GivenDemangledName) {
   std::string DemangledName = GivenDemangledName;
-  if (!oclIsBuiltin(OrigName, 20,
-      DemangledName.empty() ? &DemangledName : nullptr))
+  if (!oclIsBuiltin(OrigName, DemangledName.empty() ? &DemangledName : nullptr))
     return ~0U;
   DEBUG(dbgs() << "getExtOp: demangled name: " << DemangledName << '\n');
   OCLExtOpKind EOC;

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -605,13 +605,11 @@ Op getSPIRVFuncOC(const std::string& Name,
 bool getSPIRVBuiltin(const std::string &Name, spv::BuiltIn &Builtin);
 
 /// \param Name LLVM function name
-/// \param OpenCLVer version of OpenCL source file. Suppotred values are 12, 20
-/// and 21.
 /// \param DemangledName demanged name of the OpenCL built-in function
 /// \returns true if Name is the name of the OpenCL built-in function,
 /// false for other functions
-bool oclIsBuiltin(const StringRef& Name, unsigned SrcLangVer = 12,
-    std::string* DemangledName = nullptr, bool isCPP = false);
+bool oclIsBuiltin(const StringRef &Name, std::string *DemangledName = nullptr,
+                  bool isCPP = false);
 
 /// Check if a function type is void(void).
 bool isVoidFuncTy(FunctionType *FT);

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -226,7 +226,7 @@ private:
             // Handle context_ptr = spir_get_block_context(block)
             lowerGetBlockContext(CI, Ctx);
             changed = true;
-          } else if (oclIsBuiltin(Name, 20, &DemangledName)) {
+          } else if (oclIsBuiltin(Name, &DemangledName)) {
             lowerBlockBuiltin(CI, InvF, Ctx, CtxLen, CtxAlign, DemangledName);
             changed = true;
           } else

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -943,12 +943,13 @@ SPIRVToLLVM::postProcessOCL() {
   std::string DemangledName;
   SPIRVWord SrcLangVer = 0;
   BM->getSourceLanguage(&SrcLangVer);
+  bool isCPP = SrcLangVer == kOCLVer::CL21;
   for (auto I = M->begin(), E = M->end(); I != E;) {
     auto F = I++;
     if (F->hasName() && F->isDeclaration()) {
       DEBUG(dbgs() << "[postProcessOCL sret] " << *F << '\n');
       if (F->getReturnType()->isStructTy() &&
-          oclIsBuiltin(F->getName(), SrcLangVer, &DemangledName)) {
+          oclIsBuiltin(F->getName(), &DemangledName, isCPP)) {
         if (!postProcessOCLBuiltinReturnStruct(F))
           return false;
       }
@@ -968,8 +969,7 @@ SPIRVToLLVM::postProcessOCL() {
     auto F = I++;
     if (F->hasName() && F->isDeclaration()) {
       DEBUG(dbgs() << "[postProcessOCL array arg] " << *F << '\n');
-      if (hasArrayArg(F) &&
-          oclIsBuiltin(F->getName(), SrcLangVer, &DemangledName))
+      if (hasArrayArg(F) && oclIsBuiltin(F->getName(), &DemangledName, isCPP))
         if (!postProcessOCLBuiltinWithArrayArguments(F, DemangledName))
           return false;
     }

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -165,7 +165,7 @@ SPIRVToOCL20::visitCallInst(CallInst& CI) {
   auto MangledName = F->getName();
   std::string DemangledName;
   Op OC = OpNop;
-  if (!oclIsBuiltin(MangledName, 20, &DemangledName) ||
+  if (!oclIsBuiltin(MangledName, &DemangledName) ||
       (OC = getSPIRVFuncOC(DemangledName)) == OpNop)
     return;
   DEBUG(dbgs() << "DemangledName = " << DemangledName.c_str() << '\n'
@@ -479,7 +479,7 @@ void SPIRVToOCL20::translateMangledAtomicTypeName() {
       continue;
     std::string MangledName = I.getName();
     std::string DemangledName;
-    if (!oclIsBuiltin(MangledName, 20, &DemangledName) ||
+    if (!oclIsBuiltin(MangledName, &DemangledName) ||
         DemangledName.find(kOCLBuiltinName::AtomPrefix) != 0)
       continue;
     auto Loc = MangledName.find(kOCLBuiltinName::AtomPrefix);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -455,7 +455,7 @@ getSPIRVFuncOC(const std::string& S, SmallVectorImpl<std::string> *Dec) {
   Op OC;
   SmallVector<StringRef, 2> Postfix;
   std::string Name;
-  if (!oclIsBuiltin(S, 20, &Name))
+  if (!oclIsBuiltin(S, &Name))
     Name = S;
   StringRef R(Name);
   R = dePrefixSPIRVName(R, Postfix);
@@ -476,8 +476,8 @@ getSPIRVBuiltin(const std::string &OrigName, spv::BuiltIn &B) {
   return getByName(R.str(), B);
 }
 
-bool oclIsBuiltin(const StringRef &Name, unsigned SrcLangVer,
-                  std::string *DemangledName, bool isCPP) {
+bool oclIsBuiltin(const StringRef &Name, std::string *DemangledName,
+                  bool isCPP) {
   if (Name == "printf") {
     if (DemangledName)
       *DemangledName = Name;

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -74,7 +74,7 @@ namespace kExt {
   const char SpirvBinary[] = ".spv";
   const char SpirvText[] = ".spt";
   const char LLVMBinary[] = ".bc";
-};
+}
 
 using namespace llvm;
 


### PR DESCRIPTION
- Delete OpenCLVer parameter of oclIsBuiltin function. This parameter was used to detect CPP kernel language and was later replaced by isCPP parameter.
- Fixed detection of OpenCL 2.0+ in OCL20To12 module pass.
- Fixed warnings about defining unused variables and extra semicolon.
