### PR TITLE
Using IDs instead of literals in OpControlBarrier

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2251,18 +2251,21 @@ Instruction *
 SPIRVToLLVM::transOCLBarrierFence(SPIRVInstruction* MB, BasicBlock *BB) {
   assert(BB && "Invalid BB");
   std::string FuncName;
+  auto getIntVal = [](SPIRVValue *value){
+    return static_cast<SPIRVConstant*>(value)->getZExtIntValue();
+  };
   SPIRVWord MemSema = 0;
   if (MB->getOpCode() == OpMemoryBarrier) {
     auto MemB = static_cast<SPIRVMemoryBarrier*>(MB);
     FuncName = "mem_fence";
-    MemSema = MemB->getOpWord(1);
+    MemSema = getIntVal(MemB->getOpValue(1));
   } else if (MB->getOpCode() == OpControlBarrier) {
     auto CtlB = static_cast<SPIRVControlBarrier*>(MB);
     SPIRVWord Ver = 1;
     BM->getSourceLanguage(&Ver);
     FuncName = (Ver <= 12) ? kOCLBuiltinName::Barrier :
         kOCLBuiltinName::WorkGroupBarrier;
-    MemSema = CtlB->getMemSemantic();
+    MemSema = getIntVal(CtlB->getMemSemantic());
   } else {
     llvm_unreachable("Invalid instruction");
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1510,11 +1510,11 @@ SPIRVInstruction *
 LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
     CallInst* CI, SPIRVBasicBlock* BB) {
   switch (OC) {
-  case OpControlBarrier:
+  case OpControlBarrier: {
+    auto BArgs = transValue(getArguments(CI), BB);
     return BM->addControlBarrierInst(
-        getArgAsScope(CI, 0),
-        getArgAsScope(CI, 1),
-        getArgAsInt(CI, 2), BB);
+      BArgs[0], BArgs[1], BArgs[2], BB);
+    }
     break;
   case OpGroupAsyncCopy: {
     auto BArgs = transValue(getArguments(CI), BB);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1593,11 +1593,11 @@ class SPIRVControlBarrier:public SPIRVInstruction {
 public:
   static const Op OC = OpControlBarrier;
   // Complete constructor
-  SPIRVControlBarrier(Scope TheScope,
-      Scope TheMemScope, SPIRVWord TheMemSema,
+  SPIRVControlBarrier(SPIRVValue *TheScope,
+      SPIRVValue *TheMemScope, SPIRVValue *TheMemSema,
       SPIRVBasicBlock *TheBB)
-    :SPIRVInstruction(4, OC, TheBB),ExecScope(TheScope),
-     MemScope(TheMemScope), MemSema(TheMemSema){
+    :SPIRVInstruction(4, OC, TheBB), ExecScope(TheScope->getId()),
+    MemScope(TheMemScope->getId()), MemSema(TheMemSema->getId()){
     validate();
     assert(TheBB && "Invalid BB");
   }
@@ -1609,17 +1609,15 @@ public:
   void setWordCount(SPIRVWord TheWordCount) {
     SPIRVEntry::setWordCount(TheWordCount);
   }
-  Scope getExecScope() const {
-    return ExecScope;
-  }
-  Scope getMemScope() const {
-    return MemScope;
-  }
-  bool hasMemSemantic() const {
-    return MemSema != 0;
-  }
-  SPIRVWord getMemSemantic() const {
-    return MemSema;
+  SPIRVValue *getExecScope() const { return getValue(ExecScope); }
+  SPIRVValue *getMemScope() const { return getValue(MemScope); }
+  SPIRVValue *getMemSemantic() const { return getValue(MemSema); }
+  std::vector<SPIRVValue *> getOperands() {
+    std::vector<SPIRVId> Operands;
+    Operands.push_back(ExecScope);
+    Operands.push_back(MemScope);
+    Operands.push_back(MemSema);
+    return getValues(Operands);
   }
 protected:
   _SPIRV_DEF_ENCDEC3(ExecScope, MemScope, MemSema)
@@ -1627,12 +1625,10 @@ protected:
     assert(OpCode == OC);
     assert(WordCount == 4);
     SPIRVInstruction::validate();
-    isValid(ExecScope);
-    isValid(MemScope);
   }
-  Scope ExecScope;
-  Scope MemScope;
-  SPIRVWord MemSema;
+  SPIRVId ExecScope;
+  SPIRVId MemScope;
+  SPIRVId MemSema;
 };
 
 class SPIRVGroupAsyncCopy:public SPIRVInstruction {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -250,8 +250,8 @@ public:
   virtual SPIRVInstruction *addCopyMemorySizedInst(SPIRVValue *, SPIRVValue *,
       SPIRVValue *, const std::vector<SPIRVWord>&, SPIRVBasicBlock *);
   virtual SPIRVInstruction *addControlBarrierInst(
-      Scope ExecKind, Scope MemKind,
-      SPIRVWord MemSema, SPIRVBasicBlock *BB);
+      SPIRVValue *ExecKind, SPIRVValue *MemKind,
+      SPIRVValue *MemSema, SPIRVBasicBlock *BB);
   virtual SPIRVInstruction *addGroupInst(Op OpCode, SPIRVType *Type,
       Scope Scope, const std::vector<SPIRVValue *> &Ops,
       SPIRVBasicBlock *BB);
@@ -1016,8 +1016,8 @@ SPIRVModuleImpl::addCmpInst(Op TheOpCode, SPIRVType *TheType,
 }
 
 SPIRVInstruction *
-SPIRVModuleImpl::addControlBarrierInst(Scope ExecKind,
-    Scope MemKind, SPIRVWord MemSema, SPIRVBasicBlock *BB) {
+SPIRVModuleImpl::addControlBarrierInst(SPIRVValue *ExecKind,
+    SPIRVValue *MemKind, SPIRVValue *MemSema, SPIRVBasicBlock *BB) {
   return addInstruction(
       new SPIRVControlBarrier(ExecKind, MemKind, MemSema, BB), BB);
 }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -252,8 +252,8 @@ public:
   virtual SPIRVInstruction *addCmpInst(Op, SPIRVType *, SPIRVValue *,
       SPIRVValue *, SPIRVBasicBlock *) = 0;
   virtual SPIRVInstruction *addControlBarrierInst(
-      Scope ExecKind, Scope MemKind,
-      SPIRVWord MemSema, SPIRVBasicBlock *BB) = 0;
+      SPIRVValue *ExecKind, SPIRVValue *MemKind,
+      SPIRVValue *MemSema, SPIRVBasicBlock *BB) = 0;
   virtual SPIRVInstruction *addGroupInst(Op OpCode, SPIRVType *Type,
       Scope Scope, const std::vector<SPIRVValue *> &Ops,
       SPIRVBasicBlock *BB) = 0;

--- a/test/SPIRV/transcoding/OpControlBarrier.ll
+++ b/test/SPIRV/transcoding/OpControlBarrier.ll
@@ -1,0 +1,58 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func void @_Z18work_group_barrierj(i32 2)
+; CHECK-LLVM: call spir_func void @_Z18work_group_barrierj(i32 1)
+; CHECK-LLVM: call spir_func void @_Z18work_group_barrierj(i32 4)
+
+; CHECK-SPIRV-DAG: 4 ControlBarrier [[Scope1:[0-9]+]] [[Scope2:[0-9]+]] [[MemSema1:[0-9]+]]
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[Scope1]] {{[0-9]+}} 
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[Scope2]] {{[0-9]+}} 
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1]] {{[0-9]+}} 
+
+; CHECK-SPIRV-DAG: 4 ControlBarrier [[Scope1]] [[Scope2]] [[MemSema2:[0-9]+]]
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2]] {{[0-9]+}} 
+
+; CHECK-SPIRV-DAG: 4 ControlBarrier [[Scope1]] [[Scope2]] [[MemSema3:[0-9]+]]
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3]] {{[0-9]+}} 
+
+; ModuleID = 'P:\work_group_barrier.cl'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test() #0 {
+entry:
+  tail call spir_func void @_Z18work_group_barrierj(i32 2) #2
+  tail call spir_func void @_Z18work_group_barrierj(i32 1) #2
+  tail call spir_func void @_Z18work_group_barrierj(i32 4) #2
+  ret void
+}
+
+declare spir_func void @_Z18work_group_barrierj(i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void ()* @test, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space"}
+!2 = !{!"kernel_arg_access_qual"}
+!3 = !{!"kernel_arg_type"}
+!4 = !{!"kernel_arg_base_type"}
+!5 = !{!"kernel_arg_type_qual"}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}


### PR DESCRIPTION
This pull requests address the issue described here: https://github.com/KhronosGroup/SPIRV-LLVM/issues/47

During validation process of these changes I found a few other issues:
- some arguments of OpControlBarrier are dropped during conversion from SPIR-V to OpenCL 1.2/2.0
- some arguments of OpMemoryBarrier are dropped during conversion from SPIR-V to OpenCL 1.2/2.0
- OpMemoryBarrier produces always mem_fence, but it should produce atomic_work_item_fence for OpenCL 2.0

I'll create a new ticket to address the above issues.
