### PR TITLE
[SPIR-V] Fix translation of get_image_channel_{order|data_type}.

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -251,6 +251,12 @@ public:
   void visitCallScalToVec(CallInst *CI, StringRef MangledName,
                           const std::string &DemangledName);
 
+  /// Transform get_image_channel_{order|data_type} built-in functions to
+  ///   __spirv_ocl_{ImageQueryOrder|ImageQueryFormat}
+  void visitCallGetImageChannel(CallInst *CI, StringRef MangledName,
+                                const std::string &DemangledName,
+                                unsigned int Offset);
+
   void visitDbgInfoIntrinsic(DbgInfoIntrinsic &I){
     I.dropAllReferences();
     I.eraseFromParent();
@@ -488,6 +494,16 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
       DemangledName == kOCLBuiltinName::Clamp ||
       DemangledName == kOCLBuiltinName::Mix) {
     visitCallScalToVec(&CI, MangledName, DemangledName);
+    return;
+  }
+  if (DemangledName == kOCLBuiltinName::GetImageChannelDataType) {
+    visitCallGetImageChannel(&CI, MangledName, DemangledName,
+                             OCLImageChannelDataTypeOffset);
+    return;
+  }
+  if (DemangledName == kOCLBuiltinName::GetImageChannelOrder) {
+    visitCallGetImageChannel(&CI, MangledName, DemangledName,
+                             OCLImageChannelOrderOffset);
     return;
   }
   visitCallBuiltinSimple(&CI, MangledName, DemangledName);
@@ -1322,7 +1338,6 @@ OCL20ToSPIRV::visitCallVecLoadStore(CallInst* CI,
   transBuiltin(CI, Info);
 }
 
-
 void OCL20ToSPIRV::visitCallGetFence(CallInst *CI, StringRef MangledName,
                                      const std::string &DemangledName) {
   AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
@@ -1407,6 +1422,22 @@ void OCL20ToSPIRV::visitCallScalToVec(CallInst *CI, StringRef MangledName,
                                    getExtOp(MangledName, DemangledName));
       },
       &Attrs);
+}
+
+void OCL20ToSPIRV::visitCallGetImageChannel(CallInst *CI, StringRef MangledName,
+                                            const std::string &DemangledName,
+                                            unsigned int Offset) {
+  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
+  Op OC = OpNop;
+  OCLSPIRVBuiltinMap::find(DemangledName, &OC);
+  std::string SPIRVName = getSPIRVFuncName(OC);
+  mutateCallInstSPIRV(M, CI, [=](CallInst *, std::vector<Value *> &Args,
+                                 Type *&Ret) { return SPIRVName; },
+                      [=](CallInst *NewCI) -> Instruction * {
+                        return BinaryOperator::CreateAdd(
+                            NewCI, getInt32(M, Offset), "", CI);
+                      },
+                      &Attrs);
 }
 }
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -157,6 +157,8 @@ namespace kOCLBuiltinName {
   const static char FMin[]               = "fmin";
   const static char GetFence[]           = "get_fence";
   const static char GetImageArraySize[]  = "get_image_array_size";
+  const static char GetImageChannelOrder[]    = "get_image_channel_order";
+  const static char GetImageChannelDataType[] = "get_image_channel_data_type";
   const static char GetImageDepth[]      = "get_image_depth";
   const static char GetImageDim[]        = "get_image_dim";
   const static char GetImageHeight[]     = "get_image_height";
@@ -200,6 +202,12 @@ namespace kOCLBuiltinName {
   const static char SubGroupAny[]        = "sub_group_any";
   const static char WorkPrefix[]         = "work_";
 }
+
+/// Offset for OpenCL image channel order enumeration values.
+const unsigned int OCLImageChannelOrderOffset = 0x10B0;
+
+/// Offset for OpenCL image channel data type enumeration values.
+const unsigned int OCLImageChannelDataTypeOffset = 0x10D0;
 
 /// OCL 1.x atomic memory order when translated to 2.0 atomics.
 const OCLMemOrderKind OCLLegacyAtomicMemOrder = OCLMO_seq_cst;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1800,6 +1800,12 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction* BI,
   }
   if (OC == OpGenericPtrMemSemantics)
     return BinaryOperator::CreateShl(CI, getInt32(M, 8), "", BB);
+  if (OC == OpImageQueryFormat)
+    return BinaryOperator::CreateSub(
+        CI, getInt32(M, OCLImageChannelDataTypeOffset), "", BB);
+  if (OC == OpImageQueryOrder)
+    return BinaryOperator::CreateSub(
+        CI, getInt32(M, OCLImageChannelOrderOffset), "", BB);
   if (OC == OpBuildNDRange)
     return postProcessOCLBuildNDRange(BI, CI, DemangledName);
   if (OC == OpGroupAll || OC == OpGroupAny)

--- a/test/SPIRV/transcoding/image_channel.ll
+++ b/test/SPIRV/transcoding/image_channel.ll
@@ -1,0 +1,63 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_t = type opaque
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[DataTypeOffsetId:[0-9]+]] 4304
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[OrderOffsetId:[0-9]+]] 4272 
+
+; Function Attrs: nounwind
+define spir_kernel void @f(%opencl.image2d_t addrspace(1)* %img, i32 addrspace(1)* nocapture %type, i32 addrspace(1)* nocapture %order) #0 {
+; CHECK-LLVM-DAG: [[DTCALL:%.+]] ={{.*}} call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d
+; CHECK-LLVM: [[DTSUB:%.+]] = sub i32 [[DTCALL]], 4304
+; CHECK-LLVM: [[DTADD:%.+]] = add i32 [[DTSUB]], 4304
+; CHECK-LLVM: store i32 [[DTADD]]
+; CHECK-SPIRV: 4 ImageQueryFormat {{[0-9]+}} [[DataTypeID:[0-9]+]]
+; CHECK-SPIRV: 5 IAdd {{[0-9]+}} [[DTAddID:[0-9]+]] [[DataTypeID]] [[DataTypeOffsetId]]
+; CHECK-SPIRV: 5 Store {{[0-9]+}} [[DTAddID]]
+  %1 = tail call spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d(%opencl.image2d_t addrspace(1)* %img) #2
+  store i32 %1, i32 addrspace(1)* %type, align 4
+; CHECK-LLVM-DAG: [[OCALL:%.+]] ={{.*}} call spir_func i32 @_Z23get_image_channel_order11ocl_image2d
+; CHECK-LLVM: [[OSUB:%.+]] = sub i32 [[OCALL]], 4272
+; CHECK-LLVM: [[OADD:%.+]] = add i32 [[OSUB]], 4272
+; CHECK-LLVM: store i32 [[OADD]]
+; CHECK-SPIRV: 4 ImageQueryOrder {{[0-9]+}} [[OrderID:[0-9]+]]
+; CHECK-SPIRV: 5 IAdd {{[0-9]+}} [[OrderAddID:[0-9]+]] [[OrderID]] [[OrderOffsetId]]
+; CHECK-SPIRV: 5 Store {{[0-9]+}} [[OrderAddID]]
+  %2 = tail call spir_func i32 @_Z23get_image_channel_order11ocl_image2d(%opencl.image2d_t addrspace(1)* %img) #2
+  store i32 %2, i32 addrspace(1)* %order, align 4
+  ret void
+}
+
+declare spir_func i32 @_Z27get_image_channel_data_type11ocl_image2d(%opencl.image2d_t addrspace(1)*) #1
+
+declare spir_func i32 @_Z23get_image_channel_order11ocl_image2d(%opencl.image2d_t addrspace(1)*) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!9}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (%opencl.image2d_t addrspace(1)*, i32 addrspace(1)*, i32 addrspace(1)*)* @f, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"read_only", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"image2d_t", !"int*", !"int*"}
+!4 = !{!"kernel_arg_base_type", !"image2d_t", !"int*", !"int*"}
+!5 = !{!"kernel_arg_type_qual", !"", !"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}
+!9 = !{!"cl_images"}


### PR DESCRIPTION
get_image_channel_data_type returns values starting from 0x10D0 (CLK_SNORM_INT8) by SPIR 1.2 specification (https://www.khronos.org/registry/spir/specs/spir_spec-1.2.pdf).
This built-in function is mapped to OpImageQueryFormat which returns values that starts from 0x0 (CLK_SNORM_INT8).
This patch fixes translation by adding 0x10D0 offset to OpImageQueryFormat value.

Similar approach is applied to get_image_channel_order built-in function translation.
