### PR TITLE
[SPIR-V] Fix translation of opencl.used.extensions and opencl.used.op…

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -752,10 +752,16 @@ std::string getMDOperandAsString(MDNode* N, unsigned I);
 Type* getMDOperandAsType(MDNode* N, unsigned I);
 
 /// Get a named metadata as a set of string.
-/// Assume the named metadata has one or more operands each of which contains
-/// one string.
+/// Assume the named metadata has one or more operands each of which might
+/// contain set of strings. For instance:
+/// !opencl.used.optional.core.features = !{!0}
+/// !0 = !{!"cl_doubles", !"cl_images"}
+/// or if we linked two modules we may have
+/// !opencl.used.optional.core.features = !{!0, !1}
+/// !0 = !{!"cl_doubles"}
+/// !1 = !{!"cl_images"}
 std::set<std::string> getNamedMDAsStringSet(Module *M,
-    const std::string &MDName);
+                                            const std::string &MDName);
 
 /// Get SPIR-V language by SPIR-V metadata spirv.Source
 std::tuple<unsigned, unsigned, std::string>

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -899,12 +899,8 @@ getNamedMDAsStringSet(Module *M, const std::string &MDName) {
     MDNode *MD = NamedMD->getOperand(I);
     if (!MD || MD->getNumOperands() == 0)
       continue;
-    assert(MD->getNumOperands() == 1 && "Invalid SPIR");
-    auto S = getMDOperandAsString(MD, 0);
-    SmallVector<StringRef, 10> Exts;
-    StringRef(S).split(Exts, " ", -1, false);
-    for (auto S:Exts)
-      StrSet.insert(std::move(S.str()));
+    for (unsigned J = 0, N = MD->getNumOperands(); J != N; ++J)
+      StrSet.insert(std::move(getMDOperandAsString(MD, J)));
   }
 
   return std::move(StrSet);

--- a/lib/SPIRV/TransOCLMD.cpp
+++ b/lib/SPIRV/TransOCLMD.cpp
@@ -129,8 +129,6 @@ TransOCLMD::visit(Module *M) {
 
   // Add extensions
   auto Exts = getNamedMDAsStringSet(M, kSPIR2MD::Extensions);
-  for (auto &&I:getNamedMDAsStringSet(M, kSPIR2MD::OptFeatures))
-      Exts.insert(std::move(I));
   if (!Exts.empty()) {
     auto N = B.addNamedMD(kSPIRVMD::Extension);
     for (auto &I:Exts)

--- a/test/SPIRV/multi_md.ll
+++ b/test/SPIRV/multi_md.ll
@@ -44,7 +44,9 @@ entry:
 
 attributes #0 = { nounwind }
 
-; CHECK-DAG: 4 Extension "cl_images"
+; "cl_images" should be encoded as BasicImage capability, 
+; but images are not used in this test case, so this capability is not required.
+; CHECK-DAG-NOT: 4 Extension "cl_images"
 ; CHECK-DAG: 8 Extension "cl_khr_int64_base_atomics"
 ; CHECK-DAG: 9 Extension "cl_khr_int64_extended_atomics"
 ; CHECK: 3 Source 3 200000
@@ -82,6 +84,6 @@ attributes #0 = { nounwind }
 !22 = !{!23, !23, i64 0}
 !23 = !{!"any pointer", !15, i64 0}
 !24 = !{!"cl_khr_int64_base_atomics"}
-!25 = !{!"cl_khr_int64_base_atomics cl_khr_int64_extended_atomics"}
+!25 = !{!"cl_khr_int64_base_atomics", !"cl_khr_int64_extended_atomics"}
 !26 = !{!"cl_images"}
 !27 = !{!""}

--- a/test/SPIRV/transcoding/OpImageSampleExplicitLod.ll
+++ b/test/SPIRV/transcoding/OpImageSampleExplicitLod.ll
@@ -65,5 +65,5 @@ attributes #1 = { nounwind readnone }
 !4 = !{!"kernel_arg_type_qual", !"", !"", !"", !"", !""}
 !5 = !{!"kernel_arg_base_type", !"image2d_depth_t", !"sampler_t", !"float*", !"float*", !"float*"}
 !6 = !{i32 2, i32 0}
-!7 = !{!" cl_khr_depth_images"}
+!7 = !{!"cl_khr_depth_images"}
 !8 = !{!"cl_images"}

--- a/test/SPIRV/transcoding/optional-core-features-multiple.ll
+++ b/test/SPIRV/transcoding/optional-core-features-multiple.ll
@@ -1,0 +1,50 @@
+; OpenCL C source
+; -----------------------------------------------
+; double d = 1.0;
+; kernel void test(read_only image2d_t img) {}
+; -----------------------------------------------
+;
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_t = type opaque
+
+@d = addrspace(1) global double 1.000000e+00, align 8
+
+; Function Attrs: nounwind readnone
+define spir_kernel void @test(%opencl.image2d_t addrspace(1)* nocapture %img) #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!9}
+!opencl.compiler.options = !{!8}
+
+!0 = !{void (%opencl.image2d_t addrspace(1)*)* @test, !1, !2, !3, !4, !5}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"read_only"}
+!3 = !{!"kernel_arg_type", !"image2d_t"}
+!4 = !{!"kernel_arg_base_type", !"image2d_t"}
+!5 = !{!"kernel_arg_type_qual", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}
+!9 = !{!"cl_doubles", !"cl_images"}
+; CHECK-SPIRV: 2 Capability Float64 
+; CHECK-SPIRV: 2 Capability ImageBasic 
+; CHECK-LLVM: {{.*}} !{!"cl_doubles", !"cl_images"}
+; CHECK-LLVM-NOT: {{.*}} !{!"cl_doubles cl_images"}


### PR DESCRIPTION
…tional.core.features metadata.

There were are few issues with translating these metadata:
1. Optional core features (double and images) was encoded not only as capabilities, but as extensions.
2. Translator expected wrong metadata format: extensions and optional core features were expected to be stored in one string delimited by space.
According to SPIR 1.2 specification each feature must be encoded as a separate string.
