### PR TITLE
[SPIR-V] Add missing Addresses capability to SPIR-V files with non-logical addressing model.

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -62,7 +62,7 @@ namespace SPIRV{
   /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
   /// generator's magic number in the generated SPIR-V module.
   /// This number should be bumped up whenever the generated SPIR-V changes.
-  const static unsigned short kTranslatorVer = 12;
+  const static unsigned short kTranslatorVer = 13;
 
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1155,8 +1155,6 @@ LLVMToSPIRV::transCallInst(CallInst *CI, SPIRVBasicBlock *BB) {
     BB);
 }
 
-
-
 bool
 LLVMToSPIRV::transAddressingMode() {
   Triple TargetTriple(M->getTargetTriple());
@@ -1170,6 +1168,8 @@ LLVMToSPIRV::transAddressingMode() {
     BM->setAddressingModel(AddressingModelPhysical32);
   else
     BM->setAddressingModel(AddressingModelPhysical64);
+  // Physical addressing model requires Addresses capability
+  BM->addCapability(CapabilityAddresses);
   return true;
 }
 std::vector<SPIRVValue*>

--- a/test/SPIRV/empty.ll
+++ b/test/SPIRV/empty.ll
@@ -4,6 +4,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
+; CHECK: Capability Addresses
 ; CHECK: "foo"
 define spir_kernel void @foo(i32 addrspace(1)* %a) #0 {
 entry:


### PR DESCRIPTION
- Bump up translator version.
