### PR TITLE
Support for SPIRV 1.1 ExecutionModes: Initializer, Finalizer, Subgrou…

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -676,11 +676,11 @@ LLVMToSPIRV::transConstant(Value *V) {
 
   if (auto CAZero = dyn_cast<ConstantAggregateZero>(V)) {
     Type *AggType = CAZero->getType();
-    if (const StructType* ST = dyn_cast<StructType>(AggType)) {
+    if (const StructType* ST = dyn_cast<StructType>(AggType))
       if (ST->getName() == getSPIRVTypeName(kSPIRVTypeName::ConstantSampler))
         return BM->addSamplerConstant(transType(AggType), 0,0,0);
-    } else
-      return BM->addNullConstant(transType(AggType));
+
+    return BM->addNullConstant(transType(AggType));
   }
 
   if (auto ConstI = dyn_cast<ConstantInt>(V))
@@ -1393,42 +1393,37 @@ LLVMToSPIRV::transExecutionMode() {
   if (auto NMD = SPIRVMDWalker(*M).getNamedMD(kSPIRVMD::ExecutionMode)) {
     while (!NMD.atEnd()) {
       unsigned EMode = ~0U;
-      unsigned EModel = ~0U;
       Function *F = nullptr;
       auto N = NMD.nextOp(); /* execution mode MDNode */
-      N.nextOp() /* entry point MDNode */
-          .get(EModel)
-          .get(F)
-          .done()
-       .get(EMode);
-      assert (EModel == spv::ExecutionModelKernel &&
-          "Unsupported execution model");
+      N.get(F).get(EMode);
+
       SPIRVFunction *BF = static_cast<SPIRVFunction *>(getTranslatedValue(F));
       assert(BF && "Invalid kernel function");
-      switch(EMode) {
+      if (!BF)
+        return false;
+
+      switch (EMode) {
       case spv::ExecutionModeContractionOff:
+      case spv::ExecutionModeInitializer:
+      case spv::ExecutionModeFinalizer:
         BF->addExecutionMode(new SPIRVExecutionMode(BF,
-            ExecutionModeContractionOff));
+            static_cast<ExecutionMode>(EMode)));
         break;
-      case spv::ExecutionModeLocalSize: {
-        unsigned X, Y, Z;
-        N.get(X).get(Y).get(Z);
-        BF->addExecutionMode(new SPIRVExecutionMode(BF,
-            ExecutionModeLocalSize, X, Y, Z));
-      }
-      break;
+      case spv::ExecutionModeLocalSize:
       case spv::ExecutionModeLocalSizeHint: {
         unsigned X, Y, Z;
         N.get(X).get(Y).get(Z);
         BF->addExecutionMode(new SPIRVExecutionMode(BF,
-            ExecutionModeLocalSizeHint, X, Y, Z));
+            static_cast<ExecutionMode>(EMode), X, Y, Z));
       }
       break;
-      case spv::ExecutionModeVecTypeHint: {
+      case spv::ExecutionModeVecTypeHint:
+      case spv::ExecutionModeSubgroupSize:
+      case spv::ExecutionModeSubgroupsPerWorkgroup: {
         unsigned X;
         N.get(X);
         BF->addExecutionMode(new SPIRVExecutionMode(BF,
-            ExecutionModeVecTypeHint, X));
+            static_cast<ExecutionMode>(EMode), X));
       }
       break;
       default:

--- a/lib/SPIRV/TransOCLMD.cpp
+++ b/lib/SPIRV/TransOCLMD.cpp
@@ -173,7 +173,7 @@ TransOCLMD::visit(Module *M) {
 
     if (!HasFPContract)
       EM.addOp()
-        .addOp(EPNode)
+        .add(Kernel)
         .add(spv::ExecutionModeContractionOff)
         .done();
 
@@ -189,7 +189,7 @@ TransOCLMD::visit(Module *M) {
         unsigned X, Y, Z;
         decodeMDNode(MD, X, Y, Z);
         EM.addOp()
-            .addOp(EPNode)
+            .add(Kernel)
             .add(spv::ExecutionModeLocalSizeHint)
             .add(X).add(Y).add(Z)
             .done();
@@ -197,13 +197,13 @@ TransOCLMD::visit(Module *M) {
         unsigned X, Y, Z;
         decodeMDNode(MD, X, Y, Z);
         EM.addOp()
-            .addOp(EPNode)
+            .add(Kernel)
             .add(spv::ExecutionModeLocalSize)
             .add(X).add(Y).add(Z)
             .done();
       } else if (Name == kSPIR2MD::VecTyHint) {
         EM.addOp()
-            .addOp(EPNode)
+            .add(Kernel)
             .add(spv::ExecutionModeVecTypeHint)
             .add(transVecTypeHint(MD))
             .done();

--- a/test/SPIRV/ExecutionMode.ll
+++ b/test/SPIRV/ExecutionMode.ll
@@ -1,0 +1,150 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: FileCheck < %t %s
+
+; check for magic number followed by version 1.1
+; CHECK: 119734787 65792
+
+; CHECK-DAG: TypeVoid [[VOID:[0-9]+]]
+
+; CHECK-DAG: EntryPoint 6 [[WORKER:[0-9]+]] "worker"
+; CHECK-DAG: EntryPoint 6 [[INIT:[0-9]+]] "_SPIRV_GLOBAL__I_45b04794_Test_attr.cl"
+; CHECK-DAG: EntryPoint 6 [[FIN:[0-9]+]] "_SPIRV_GLOBAL__D_45b04794_Test_attr.cl"
+
+; CHECK-DAG: ExecutionMode [[WORKER]] 17 10 10 10
+; CHECK-DAG: ExecutionMode [[WORKER]] 18 12 10 1
+; CHECK-DAG: ExecutionMode [[WORKER]] 30 262149
+; CHECK-DAG: ExecutionMode [[WORKER]] 36 4
+; CHECK-DAG: ExecutionMode [[INIT]] 17 1 1 1
+; CHECK-DAG: ExecutionMode [[INIT]] 33
+; CHECK-DAG: ExecutionMode [[FIN]] 17 1 1 1
+; CHECK-DAG: ExecutionMode [[FIN]] 34
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.global_ctor_dtor = type { i32 }
+
+@g = addrspace(1) global %struct.global_ctor_dtor zeroinitializer, align 4
+
+; Function Attrs: nounwind
+define internal spir_func void @__cxx_global_var_init() #0 {
+entry:
+  call spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(%struct.global_ctor_dtor addrspace(4)* addrspacecast (%struct.global_ctor_dtor addrspace(1)* @g to %struct.global_ctor_dtor addrspace(4)*), i32 12)
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(%struct.global_ctor_dtor addrspace(4)* %this, i32 %i) unnamed_addr #1 align 2 {
+entry:
+  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  %i.addr = alloca i32, align 4
+  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
+  store i32 %i, i32* %i.addr, align 4
+  %this1 = load %struct.global_ctor_dtor addrspace(4)** %this.addr
+  %0 = load i32* %i.addr, align 4
+  call spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(%struct.global_ctor_dtor addrspace(4)* %this1, i32 %0)
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(%struct.global_ctor_dtor addrspace(4)* %this) unnamed_addr #1 align 2 {
+entry:
+  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
+  %this1 = load %struct.global_ctor_dtor addrspace(4)** %this.addr
+  call spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(%struct.global_ctor_dtor addrspace(4)* %this1) #0
+  ret void
+}
+
+; Function Attrs: nounwind
+define internal spir_func void @__dtor_g() #0 {
+entry:
+  call spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(%struct.global_ctor_dtor addrspace(4)* addrspacecast (%struct.global_ctor_dtor addrspace(1)* @g to %struct.global_ctor_dtor addrspace(4)*))
+  ret void
+}
+
+; CHECK: Function [[VOID]] [[WORKER]]
+
+; Function Attrs: nounwind
+define spir_kernel void @worker() #1 {
+entry:
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(%struct.global_ctor_dtor addrspace(4)* %this) unnamed_addr #1 align 2 {
+entry:
+  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
+  %this1 = load %struct.global_ctor_dtor addrspace(4)** %this.addr
+  %a = getelementptr inbounds %struct.global_ctor_dtor addrspace(4)* %this1, i32 0, i32 0
+  store i32 0, i32 addrspace(4)* %a, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(%struct.global_ctor_dtor addrspace(4)* %this, i32 %i) unnamed_addr #1 align 2 {
+entry:
+  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  %i.addr = alloca i32, align 4
+  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
+  store i32 %i, i32* %i.addr, align 4
+  %this1 = load %struct.global_ctor_dtor addrspace(4)** %this.addr
+  %0 = load i32* %i.addr, align 4
+  %a = getelementptr inbounds %struct.global_ctor_dtor addrspace(4)* %this1, i32 0, i32 0
+  store i32 %0, i32 addrspace(4)* %a, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define internal spir_func void @_GLOBAL__sub_I_Test_attr.cl() #0 {
+entry:
+  call spir_func void @__cxx_global_var_init()
+  ret void
+}
+
+; CHECK: Function [[VOID]] [[INIT]]
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl() #2 {
+entry:
+  call spir_func void @_GLOBAL__sub_I_Test_attr.cl()
+  ret void
+}
+
+; CHECK: Function [[VOID]] [[FIN]]
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl() #2 {
+entry:
+  call spir_func void @__dtor_g()
+  ret void
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noinline nounwind }
+
+!spirv.ExecutionMode = !{!0, !1, !2, !3, !4, !5, !6, !7}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!8}
+!opencl.ocl.version = !{!9}
+!opencl.used.extensions = !{!10}
+!opencl.used.optional.core.features = !{!10}
+!opencl.compiler.options = !{!10}
+!llvm.ident = !{!11}
+!spirv.Source = !{!12}
+
+!0 = !{void ()* @worker, i32 30, i32 262149}
+!1 = !{void ()* @worker, i32 18, i32 12, i32 10, i32 1}
+!2 = !{void ()* @worker, i32 17, i32 10, i32 10, i32 10}
+!3 = !{void ()* @worker, i32 36, i32 4}
+!4 = !{void ()* @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 33}
+!5 = !{void ()* @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
+!6 = !{void ()* @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 34}
+!7 = !{void ()* @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
+!8 = !{i32 1, i32 2}
+!9 = !{i32 2, i32 2}
+!10 = !{}
+!11 = !{!"clang version 3.6.1 "}
+!12 = !{i32 4, i32 202000}

--- a/test/SPIRV/ExecutionMode_SPIR_to_SPIRV.ll
+++ b/test/SPIRV/ExecutionMode_SPIR_to_SPIRV.ll
@@ -1,0 +1,54 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; LLVM => SPIRV checks
+; check for magic number followed by version 1.0
+; CHECK-SPIRV: 119734787 65536
+
+; CHECK-SPIRV-DAG: EntryPoint 6 [[WORKER:[0-9]+]] "worker"
+; CHECK-SPIRV-DAG: ExecutionMode [[WORKER]] 18 128 10 1
+
+
+; LLVM => SPIRV => LLVM checks
+; CHECK-LLVM: define spir_kernel void @worker()
+; CHECK-LLVM: !opencl.kernels = !{![[KERNEL_MD:[0-9]+]]}
+
+; CHECK-LLVM-DAG: ![[EXEC_MODE_MD:[0-9]+]] = !{!"work_group_size_hint", i32 128, i32 10, i32 1}
+; CHECK-LLVM-DAG: ![[KERNEL_MD]] = !{void ()* @worker, {{.*}}![[EXEC_MODE_MD]]{{.*}}}
+
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @worker() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!7}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!9}
+
+!0 = !{void ()* @worker, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space"}
+!2 = !{!"kernel_arg_access_qual"}
+!3 = !{!"kernel_arg_type"}
+!4 = !{!"kernel_arg_base_type"}
+!5 = !{!"kernel_arg_type_qual"}
+!6 = !{!"work_group_size_hint", i32 128, i32 10, i32 1}
+!7 = !{i32 1, i32 2}
+!8 = !{}
+!9 = !{!"clang version 3.6.1 "}

--- a/test/SPIRV/SPIRVVersionAutodetect_1_1.ll
+++ b/test/SPIRV/SPIRVVersionAutodetect_1_1.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: FileCheck < %t %s
+
+; check for magic number followed by version 1.1
+; CHECK: 119734787 65792
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @worker() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!spirv.ExecutionMode = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!9}
+!spirv.Source = !{!10}
+
+!0 = !{void ()* @worker, i32 33}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 2}
+!8 = !{}
+!9 = !{!"clang version 3.6.1 "}
+!10 = !{i32 4, i32 202000}


### PR DESCRIPTION
…pSize, SubgroupPerWorkgroup.

Also first parameter of !spirv.ExecutionMode subnodes should points directly to kernel function instead of !spirv.EntryPoint subnode (to match SPIRV instruction).
