### PR TITLE
Fix bug converting SPIR-V module to text form.

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2603,7 +2603,6 @@ llvm::ReadSPIRV(LLVMContext &C, std::istream &IS, Module *&M,
   M = new Module("", C);
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
 
-  BM->setAutoAddCapability(false);
   IS >> *BM;
 
   SPIRVToLLVM BTL(M, BM.get());

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -497,10 +497,14 @@ LLVMToSPIRV::transType(Type *T) {
       } else if (STName.startswith(kSPIRVTypeName::PrefixAndDelim))
         return transSPIRVOpaqueType(T);
       else if (OCLOpaqueTypeOpCodeMap::find(STName, &OpCode)) {
-        if (OpCode == OpTypePipe) {
+        switch (OpCode) {
+        default:
+          return mapType(T, BM->addOpaqueGenericType(OpCode));
+        case OpTypePipe:
           return mapType(T, BM->addPipeType());
+        case OpTypeDeviceEvent:
+          return mapType(T, BM->addDeviceEventType());
         }
-        return mapType(T, BM->addOpaqueGenericType(OpCode));
       } else if (isPointerToOpaqueStructType(T)) {
         return mapType(T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
           static_cast<SPIRAddressSpace>(AddrSpc)),

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1383,6 +1383,8 @@ std::istream &
 operator>> (std::istream &I, SPIRVModule &M) {
   SPIRVDecoder Decoder(I, M);
   SPIRVModuleImpl &MI = *static_cast<SPIRVModuleImpl*>(&M);
+  // Disable automatic capability filling.
+  MI.setAutoAddCapability(false);
 
   SPIRVWord Magic;
   Decoder >> Magic;

--- a/test/SPIRV/transcoding/spirv-types.ll
+++ b/test/SPIRV/transcoding/spirv-types.ll
@@ -3,6 +3,9 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.from-llvm.spv
+; RUN: llvm-spirv -to-binary %t.spv.txt -o %t.from-text.spv
+; RUN: cmp %t.from-llvm.spv %t.from-text.spv
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc


### PR DESCRIPTION
llvm-spirv tool with '--to-text' option added capabilities that were not actually encoded in binary form.

Also completed fix partially implemented in pull request #135.
