### PR TITLE
extractvalue/insertvalue handling

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1004,6 +1004,20 @@ LLVMToSPIRV::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         BB));
   }
 
+  if (auto Ext = dyn_cast<ExtractValueInst>(V)) {
+    return mapValue(V, BM->addCompositeExtractInst(
+        transType(Ext->getType()),
+        transValue(Ext->getAggregateOperand(), BB),
+        Ext->getIndices(), BB));
+  }
+
+  if (auto Ins = dyn_cast<InsertValueInst>(V)) {
+    return mapValue(V, BM->addCompositeInsertInst(
+        transValue(Ins->getInsertedValueOperand(), BB),
+        transValue(Ins->getAggregateOperand(), BB),
+        Ins->getIndices(), BB));
+  }
+
   if (UnaryInstruction *U = dyn_cast<UnaryInstruction>(V)) {
     if(isSamplerInitializer(U))
       return mapValue(V, transValue(U->getOperand(0), BB));

--- a/test/SPIRV/transcoding/extract_insert_value.ll
+++ b/test/SPIRV/transcoding/extract_insert_value.ll
@@ -1,0 +1,96 @@
+; ModuleID = ''
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of extractvalue/insertvalue.
+
+%struct.arr = type { [7 x float] }
+%struct.st = type { %struct.inner }
+%struct.inner = type { float }
+; CHECK-LLVM: %struct.arr = type { [7 x float] }
+; CHECK-LLVM: %struct.st = type { %struct.inner }
+; CHECK-LLVM: %struct.inner = type { float }
+
+; CHECK-LLVM:         define spir_func void @array_test
+; CHECK-LLVM-LABEL:   entry
+; CHECK-LLVM:         %0 = getelementptr inbounds %struct.arr addrspace(1)* %object, i32 0, i32 0
+; CHECK-LLVM:         %1 = load [7 x float] addrspace(1)* %0, align 4
+; CHECK-LLVM:         %2 = extractvalue [7 x float] %1, 4
+; CHECK-LLVM:         %3 = extractvalue [7 x float] %1, 2
+; CHECK-LLVM:         %4 = fadd float %2, %3
+; CHECK-LLVM:         %5 = insertvalue [7 x float] %1, float %4, 5
+; CHECK-LLVM:         store [7 x float] %5, [7 x float] addrspace(1)* %0
+
+; CHECK-SPIRV-LABEL:  5 Function
+; CHECK-SPIRV-NEXT:   FunctionParameter {{[0-9]+}} [[object:[0-9]+]]
+; CHECK-SPIRV:        6 InBoundsPtrAccessChain {{[0-9]+}} {{[0-9]+}} [[object]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV:        6 Load {{[0-9]+}} [[extracted_array:[0-9]+]] {{[0-9]+}} {{[0-9]+}} 4
+; CHECK-SPIRV:        5 CompositeExtract {{[0-9]+}} [[elem_4:[0-9]+]] [[extracted_array]] 4
+; CHECK-SPIRV:        5 CompositeExtract {{[0-9]+}} [[elem_2:[0-9]+]] [[extracted_array]] 2
+; CHECK-SPIRV:        5 FAdd {{[0-9]+}} [[add:[0-9]+]] [[elem_4]] [[elem_2]]
+; CHECK-SPIRV:        6 CompositeInsert {{[0-9]+}} [[inserted_array:[0-9]+]] [[add]] [[extracted_array]] 5
+; CHECK-SPIRV:        3 Store {{[0-9]+}} [[inserted_array]]
+; CHECK-SPIRV-LABEL:  1 FunctionEnd
+
+; Function Attrs: nounwind
+define spir_func void @array_test(%struct.arr addrspace(1)* %object) #0 {
+entry:
+  %0 = getelementptr inbounds %struct.arr addrspace(1)* %object, i32 0, i32 0
+  %1 = load [7 x float] addrspace(1)* %0, align 4
+  %2 = extractvalue [7 x float] %1, 4
+  %3 = extractvalue [7 x float] %1, 2
+  %4 = fadd float %2, %3
+  %5 = insertvalue [7 x float] %1, float %4, 5
+  store [7 x float] %5, [7 x float] addrspace(1)* %0
+  ret void
+}
+
+; CHECK-LLVM:         define spir_func void @struct_test
+; CHECK-LLVM-LABEL:   entry
+; CHECK-LLVM:         %0 = getelementptr inbounds %struct.st addrspace(1)* %object, i32 0, i32 0
+; CHECK-LLVM:         %1 = load %struct.inner addrspace(1)* %0, align 4
+; CHECK-LLVM:         %2 = extractvalue %struct.inner %1, 0
+; CHECK-LLVM:         %3 = fadd float %2, 1.000000e+00
+; CHECK-LLVM:         %4 = insertvalue %struct.inner %1, float %3, 0
+; CHECK-LLVM:         store %struct.inner %4, %struct.inner addrspace(1)* %0
+
+; CHECK-SPIRV-LABEL:  5 Function
+; CHECK-SPIRV-NEXT:   FunctionParameter {{[0-9]+}} [[object:[0-9]+]]
+; CHECK-SPIRV:        6 InBoundsPtrAccessChain {{[0-9]+}} {{[0-9]+}} [[object]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV:        6 Load {{[0-9]+}} [[extracted_struct:[0-9]+]] {{[0-9]+}} {{[0-9]+}} 4
+; CHECK-SPIRV:        5 CompositeExtract {{[0-9]+}} [[elem:[0-9]+]] [[extracted_struct]] 0
+; CHECK-SPIRV:        5 FAdd {{[0-9]+}} [[add:[0-9]+]] [[elem]] {{[0-9]+}}
+; CHECK-SPIRV:        6 CompositeInsert {{[0-9]+}} [[inserted_struct:[0-9]+]] [[add]] [[extracted_struct]] 0
+; CHECK-SPIRV:        3 Store {{[0-9]+}} [[inserted_struct]]
+; CHECK-SPIRV-LABEL:  1 FunctionEnd
+
+; Function Attrs: nounwind
+define spir_func void @struct_test(%struct.st addrspace(1)* %object) #0 {
+entry:
+  %0 = getelementptr inbounds %struct.st addrspace(1)* %object, i32 0, i32 0
+  %1 = load %struct.inner addrspace(1)* %0, align 4
+  %2 = extractvalue %struct.inner %1, 0
+  %3 = fadd float %2, 1.000000e+00
+  %4 = insertvalue %struct.inner %1, float %3, 0
+  store %struct.inner %4, %struct.inner addrspace(1)* %0
+  ret void
+}
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!0}
+!opencl.used.extensions = !{!1}
+!opencl.used.optional.core.features = !{!1}
+!opencl.compiler.options = !{!1}
+
+!0 = !{i32 1, i32 2}
+!1 = !{}


### PR DESCRIPTION
This adds handling of LLVM extractvalue/insertvalue instructions (e.g. as used for loading/storing a value from/to an array), and handling of the reverse translation from SPIR-V to LLVM in OpCompositeExtract/OpCompositeInsert.

Several notes:
- SPIR-V classifies structures, arrays, matrices and vectors as composite types. SPIRV-LLVM currently only handles vector types in OpCompositeExtract/OpCompositeInsert.
- I have only tested this for array types right now. LLVM struct types will also need testing. Since neither OpenCL nor LLVM have a native matrix type, I'm not sure how or if matrix types should be tested.
- the ExtractValueInst/InsertValueInst handling must go before the UnaryInstruction handling (in SPIRVWriter), because they are both unary instructions.
- indices in LLVM and SPIR-V match up, so no conversion is necessary.

Also, help creating proper test cases would be appreciated. Probably have to write these by hand as I can't seem to tickle extractvalue/insertvalue instructions out of LLVM for simple example code (it usually prefers GEPs instead of these).

As a more convoluted example, I currently have this:

```
%struct.raster_params = type { %class.matrix4 }
%class.matrix4 = type { %struct.const_array }
%struct.const_array = type { [16 x float] }
[...]
  %5 = getelementptr inbounds %struct.raster_params, %struct.raster_params addrspace(2)* %params, i64 0, i32 0, i32 0, i32 0
  %.unpack.unpack = load [16 x float], [16 x float] addrspace(2)* %5, align 4
  %.unpack.unpack.fca.2.extract = extractvalue [16 x float] %.unpack.unpack, 2
```

which should get translated to (misc stuff omitted):

```
          %5 = OpTypeFloat 32
          %6 = OpTypeInt 64 0
        %169 = OpConstant %6 16
        %170 = OpTypeArray %5 %169
[...]
        %217 = OpInBoundsPtrAccessChain %216 %183 %56 %58 %58 %58
        %218 = OpLoad %170 %217 Aligned 4
        %219 = OpCompositeExtract %5 %218 2
```
