### PR TITLE
Fixes ambigious else with explicit braces

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1247,11 +1247,12 @@ getSPIRVImageSampledTypeName(SPIRVType *Ty) {
   case OpTypeVoid:
     return kSPIRVImageSampledTypeName::Void;
   case OpTypeInt:
-    if (Ty->getIntegerBitWidth() == 32)
+    if (Ty->getIntegerBitWidth() == 32) {
       if (static_cast<SPIRVTypeInt *>(Ty)->isSigned())
         return kSPIRVImageSampledTypeName::Int;
       else
         return kSPIRVImageSampledTypeName::UInt;
+    }
     break;
   case OpTypeFloat:
     switch(Ty->getFloatBitWidth()) {


### PR DESCRIPTION
Adds explicit braces to prevent warning message:

warning: suggest explicit braces to avoid ambiguous 'else' [-Werror=parentheses]
