### PR TITLE
Fix missing const qualifier on comparator (MSVC)

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -189,7 +189,7 @@ SPIRVGroupMemberDecorate::decorateTargets() {
 
 bool
 SPIRVDecorateGeneric::Comparator::operator()(const SPIRVDecorateGeneric *A,
-    const SPIRVDecorateGeneric *B) {
+    const SPIRVDecorateGeneric *B) const {
   auto Action = [=](){
   if (A->getOpCode() < B->getOpCode())
     return true;

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -65,7 +65,7 @@ public:
   size_t getLiteralCount() const;
   /// Compare for kind and literal only.
   struct Comparator {
-    bool operator()(const SPIRVDecorateGeneric *A, const SPIRVDecorateGeneric *B);
+    bool operator ()(const SPIRVDecorateGeneric *A, const SPIRVDecorateGeneric *B) const;
   };
   /// Compare kind, literals and target.
   friend bool operator==(const SPIRVDecorateGeneric &A,


### PR DESCRIPTION
A const qualifier was missing on
SPIRVDecorateGeneric::Comparator::operator(), which resulted in a
compile-time error on MSVC, as const objects cannot invoke non-const
member functions.  Since both arguments to this function are const, and
this function has no side-effects, this function can be safely made
const, and therefore invokable in const expressions.

This patch enables SPIRV-LLVM to build using Visual Studio 14.0 (MSVC
19)
