### PR TITLE
Fix for translation of OpFMod instruction

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -122,11 +122,6 @@ public:
   ///   __spirv_MemoryBarrier(map(scope), map(flag)|map(order))
   void transMemoryBarrier(CallInst *CI, AtomicWorkItemFenceLiterals);
 
-  /// Transform fmod to __spirv_OpFMod.
-  /// fmod(dividend, divisor) =>
-  ///   __spirv_OpFMod(map(dividend), map(divisor))
-  void visitCallFMod(CallInst *CI);
-
   /// Transform all to __spirv_Op(All|Any).  Note that the types mismatch so
   // some extra code is emitted to convert between the two.
   void visitCallAllAny(spv::Op OC, CallInst *CI);
@@ -384,10 +379,6 @@ OCL20ToSPIRV::visitCallInst(CallInst& CI) {
     visitCallNDRange(&CI, DemangledName);
     return;
   }
-  if (DemangledName == kOCLBuiltinName::FMod) {
-      visitCallFMod(&CI);
-      return;
-  }
   if (DemangledName == kOCLBuiltinName::All) {
       visitCallAllAny(OpAll, &CI);
       return;
@@ -617,14 +608,6 @@ OCL20ToSPIRV::visitCallAtomicInit(CallInst* CI) {
   ST->takeName(CI);
   CI->dropAllReferences();
   CI->eraseFromParent();
-}
-
-void
-OCL20ToSPIRV::visitCallFMod(CallInst* CI) {
-  AttributeSet Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstSPIRV(M, CI, [=](CallInst *, std::vector<Value *> &Args) {
-    return getSPIRVFuncName(OpFMod);
-  }, &Attrs);
 }
 
 void

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -135,7 +135,6 @@ struct OCLBuiltinTransInfo {
 //
 ///////////////////////////////////////////////////////////////////////////////
 namespace kOCLBuiltinName {
-  const static char FMod[]                      = "fmod";
   const static char All[]                       = "all";
   const static char Any[]                       = "any";
   const static char AsyncWorkGroupCopy[]        = "async_work_group_copy";
@@ -529,7 +528,6 @@ _SPIRV_OP(fetch_or_explicit, AtomicOr)
 _SPIRV_OP(fetch_xor_explicit, AtomicXor)
 #undef _SPIRV_OP
 #define _SPIRV_OP(x,y) add(#x, Op##y);
-_SPIRV_OP(fmod, FMod)
 _SPIRV_OP(dot, Dot)
 _SPIRV_OP(async_work_group_copy, GroupAsyncCopy)
 _SPIRV_OP(async_work_group_strided_copy, GroupAsyncCopy)

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1794,6 +1794,36 @@ SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                                          BV->getName(), BB));
   }
 
+  case OpFMod: {
+    // translate OpFMod(a, b) to copysign(frem(a, b), b)
+    SPIRVFMod *FMod = static_cast<SPIRVFMod *>(BV);
+    auto Dividend = transValue(FMod->getDividend(), F, BB);
+    auto Divisor = transValue(FMod->getDivisor(), F, BB);
+    auto FRem = BinaryOperator::CreateFRem(Dividend, Divisor, "frem.res", BB);
+
+    std::string UnmangledName = OCLExtOpMap::map(OpenCLLIB::Copysign);
+    std::string MangledName = "copysign";
+
+    std::vector<Type *> ArgTypes;
+    ArgTypes.push_back(FRem->getType());
+    ArgTypes.push_back(Divisor->getType());
+    MangleOpenCLBuiltin(UnmangledName, ArgTypes, MangledName);
+
+    auto FT = FunctionType::get(transType(BV->getType()), ArgTypes, false);
+    auto Func = Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
+    Func->setCallingConv(CallingConv::SPIR_FUNC);
+    if (isFuncNoUnwind())
+      Func->addFnAttr(Attribute::NoUnwind);
+
+    std::vector<Value *> Args;
+    Args.push_back(FRem);
+    Args.push_back(Divisor);
+
+    auto Call = CallInst::Create(Func, Args, "copysign", BB);
+    setCallingConv(Call);
+    addFnAttr(Context, Call, Attribute::NoUnwind);
+    return mapValue(BV, Call);
+  }
   case OpFNegate: {
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
     return mapValue(

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1617,11 +1617,6 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC,
                                  BArgs[4], BArgs[5], BB);
     }
     break;
-  case OpFMod: {
-    auto BArgs = transValue(getArguments(CI), BB);
-    return BM->addFModInst(transType(CI->getType()),
-                           BArgs[0]->getId(), BArgs[1]->getId(), BB);
-  }
   default: {
     if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
       return BM->addUnaryInst(OC, transType(CI->getType()),

--- a/test/SPIRV/OpFMod.spt
+++ b/test/SPIRV/OpFMod.spt
@@ -1,0 +1,65 @@
+119734787 65536 458752 27 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Float64
+2 Capability Int64
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2
+6 EntryPoint 6 2 "fmath_spv"
+3 Source 3 102000
+3 Name 3 "res"
+3 Name 4 "lhs"
+3 Name 5 "rhs"
+4 Name 6 "entry"
+9 Name 8 "__spirv_GlobalInvocationId"
+4 Decorate 7 FuncParamAttr 5
+2 DecorationGroup 7
+4 Decorate 8 BuiltIn 28
+3 Decorate 8 Constant
+11 Decorate 8 LinkageAttributes "__spirv_GlobalInvocationId" Import
+5 GroupDecorate 7 3 4 5
+4 TypeInt 9 64 0
+5 Constant 9 16 32 0
+4 TypeVector 10 9 3
+4 TypePointer 11 0 10
+2 TypeVoid 12
+3 TypeFloat 13 64
+4 TypePointer 14 5 13
+6 TypeFunction 15 12 14 14 14
+4 Variable 11 8 0
+
+5 Function 12 2 0 15
+3 FunctionParameter 14 3
+3 FunctionParameter 14 4
+3 FunctionParameter 14 5
+
+2 Label 6
+6 Load 10 17 8 2 0
+5 CompositeExtract 9 18 17 0
+5 ShiftLeftLogical 9 19 18 16
+5 ShiftRightArithmetic 9 20 19 16
+5 InBoundsPtrAccessChain 14 21 4 20
+6 Load 13 22 21 2 8
+5 InBoundsPtrAccessChain 14 23 5 20
+6 Load 13 24 23 2 8
+5 FMod 13 25 22 24
+5 InBoundsPtrAccessChain 14 26 3 20
+5 Store 26 25 2 8
+1 Return
+
+1 FunctionEnd
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: 5 FMod {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} {{[0-9]*}}
+
+; CHECK-LLVM: %frem.res = frem double %[[dividend:[0-9]+]], %[[divisor:[0-9]+]]
+; CHECK-LLVM: %copysign = call spir_func double @_Z8copysigndd(double %frem.res, double %[[divisor]]) #0
+; CHECK-LLVM: %[[ptr:[0-9]+]] = getelementptr inbounds double addrspace(1)* %res, i64 %{{[0-9]*}}
+; CHECK-LLVM: store double %copysign, double addrspace(1)* %[[ptr]], align 8
+  

--- a/test/SPIRV/fmod.ll
+++ b/test/SPIRV/fmod.ll
@@ -8,13 +8,12 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-SPIRV: 5 FMod {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 7 ExtInst {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} fmod {{[0-9]+}} {{[0-9]+}}
 ; CHECK-LLVM: call spir_func float @_Z4fmodff
 ; CHECK-LLVM: declare spir_func float @_Z4fmodff(float, float)
 
-; ModuleID = 'test.bc'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
-target triple = "spir64-unkwnown-unknown"
+target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
 define spir_kernel void @fmod_kernel(float %out, float %in1, float %in2) #0 {
@@ -48,4 +47,4 @@ attributes #2 = { nounwind readnone }
 !6 = !{i32 1, i32 2}
 !7 = !{i32 2, i32 0}
 !8 = !{}
-!9 = !{!"clang version 3.6.1"}
+!9 = !{!"clang version 3.6.1"} 


### PR DESCRIPTION
OpFMod(a, b) should be translated to copysign(frem(a, b), b)
