### PR TITLE
Adds handling for llvm.memmove-intrinsic

### DIFF
--- a/include/llvm/Support/SPIRV.h
+++ b/include/llvm/Support/SPIRV.h
@@ -56,6 +56,7 @@ void initializeOCLTypeToSPIRVPass(PassRegistry&);
 void initializeSPIRVLowerBoolPass(PassRegistry&);
 void initializeSPIRVLowerConstExprPass(PassRegistry&);
 void initializeSPIRVLowerOCLBlocksPass(PassRegistry&);
+void initializeSPIRVLowerMemmovePass(PassRegistry&);
 void initializeSPIRVRegularizeLLVMPass(PassRegistry&);
 void initializeSPIRVToOCL20Pass(PassRegistry&);
 void initializeTransOCLMDPass(PassRegistry&);
@@ -134,6 +135,9 @@ ModulePass *createSPIRVLowerConstExpr();
 
 /// Create a pass for lowering OCL 2.0 blocks to functions calls.
 ModulePass *createSPIRVLowerOCLBlocks();
+
+/// Create a pass for lowering llvm.memmove to llvm.memcpys with a temporary variable.
+ModulePass *createSPIRVLowerMemmove();
 
 /// Create a pass for regularize LLVM module to be translated to SPIR-V.
 ModulePass *createSPIRVRegularizeLLVM();

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -30,6 +30,7 @@ add_llvm_library(LLVMSPIRVLib
   SPIRVLowerBool.cpp
   SPIRVLowerConstExpr.cpp
   SPIRVLowerOCLBlocks.cpp
+  SPIRVLowerMemmove.cpp
   SPIRVReader.cpp
   SPIRVRegularizeLLVM.cpp
   SPIRVToOCL20.cpp

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -1,0 +1,139 @@
+//===- SPIRVLowerMemmove.cpp - Lower llvm.memmove to llvm.memcpys ----------===//
+//
+//                     The LLVM/SPIRV Translator
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (c) 2014 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimers in the documentation
+// and/or other materials provided with the distribution.
+// Neither the names of Advanced Micro Devices, Inc., nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements lowering llvm.memmove into several llvm.memcpys.
+//
+//===----------------------------------------------------------------------===//
+#define DEBUG_TYPE "spvmemmove"
+
+#include "SPIRVInternal.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Pass.h"
+#include "llvm/PassSupport.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace SPIRV;
+
+namespace SPIRV {
+cl::opt<bool> SPIRVLowerMemmoveValidate("spvmemmove-validate",
+    cl::desc("Validate module after lowering llvm.memmove instructions into " 
+        "llvm.memcpy"));
+
+class SPIRVLowerMemmove: public ModulePass,
+  public InstVisitor<SPIRVLowerMemmove> {
+public:
+  SPIRVLowerMemmove():ModulePass(ID), Context(nullptr) {
+    initializeSPIRVLowerMemmovePass(*PassRegistry::getPassRegistry());
+  }
+  virtual void visitMemMoveInst(MemMoveInst &I) {
+    IRBuilder<> Builder(I.getParent());
+    Builder.SetInsertPoint(&I);
+    auto *Dest = I.getRawDest();
+    auto *Src = I.getRawSource();
+    auto *SrcTy = Src->getType();
+    if (!isa<ConstantInt>(I.getLength())) 
+        // ToDo: for non-constant length, could use a loop to copy a 
+        // fixed length chunk at a time. For now simply fail
+        report_fatal_error("llvm.memmove of non-constant length not supported", 
+            false);
+    auto *Length = cast<ConstantInt>(I.getLength());
+    if (isa<BitCastInst>(Src)) 
+        // The source could be bit-cast from another type,
+        // need the original type for the allocation of the temporary variable
+        SrcTy = cast<BitCastInst>(Src)->getOperand(0)->getType();
+    auto Align = I.getAlignment();
+    auto Volatile = I.isVolatile();
+    Value *NumElements = nullptr;
+    uint64_t ElementsCount = 1;
+    if (SrcTy->isArrayTy()) {
+        NumElements = Builder.getInt32(SrcTy->getArrayNumElements());
+        ElementsCount = SrcTy->getArrayNumElements();
+    }
+    if (Mod->getDataLayout()->getTypeSizeInBits(SrcTy->getPointerElementType()) 
+        * ElementsCount !=  Length->getZExtValue() * 8)
+        report_fatal_error("Size of the memcpy should match the allocated memory", 
+            false);
+
+    auto *Alloca = Builder.CreateAlloca(SrcTy->getPointerElementType(), 
+        NumElements);
+    auto *LifetimeStart = Builder.CreateLifetimeStart(Alloca);
+    auto *FirstCpy = Builder.CreateMemCpy(Alloca, Src, Length, Align, Volatile);
+    auto *SecondCpy = Builder.CreateMemCpy(Dest, Alloca, Length, Align, 
+        Volatile);
+    auto *LifetimeEnd = Builder.CreateLifetimeEnd(Alloca);
+
+    SecondCpy->takeName(&I);
+    I.replaceAllUsesWith(SecondCpy);
+    I.dropAllReferences();
+    I.eraseFromParent();
+  }
+  virtual bool runOnModule(Module &M) {
+    Context = &M.getContext();
+    Mod = &M;
+    visit(M);
+
+    if (SPIRVLowerMemmoveValidate) {
+      DEBUG(dbgs() << "After SPIRVLowerMemmove:\n" << M);
+      std::string Err;
+      raw_string_ostream ErrorOS(Err);
+      if (verifyModule(M, &ErrorOS)){
+        Err = std::string("Fails to verify module: ") + Err;
+        report_fatal_error(Err.c_str(), false);
+      }
+    }
+    return true;
+  }
+
+  static char ID;
+private:
+  LLVMContext *Context;
+  Module *Mod;
+};
+
+char SPIRVLowerMemmove::ID = 0;
+}
+
+INITIALIZE_PASS(SPIRVLowerMemmove, "spvmemmove",
+    "Lower llvm.memmove into llvm.memcpy", false, false)
+
+ModulePass *llvm::createSPIRVLowerMemmove() {
+  return new SPIRVLowerMemmove();
+}

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1838,6 +1838,7 @@ addPassesForSPIRV(PassManager &PassMgr) {
   PassMgr.add(createSPIRVRegularizeLLVM());
   PassMgr.add(createSPIRVLowerConstExpr());
   PassMgr.add(createSPIRVLowerBool());
+  PassMgr.add(createSPIRVLowerMemmove());
 }
 
 bool

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1878,8 +1878,7 @@ protected:
     assert(Obj->getStorageClass() == StorageClassFunction &&
         "Invalid storage class");
     assert(Obj->getType()->isTypePointer() &&
-        Obj->getType()->getPointerElementType()->isTypeInt() &&
-        "Object type must be an integer type scalar");
+        "Objects type must be a pointer");
     if (!Obj->getType()->getPointerElementType()->isTypeVoid() ||
         !Module->hasCapability(CapabilityAddresses))
       assert(Size == 0 && "Size must be 0");

--- a/test/SPIRV/transcoding/llvm.memmove.ll
+++ b/test/SPIRV/transcoding/llvm.memmove.ll
@@ -1,0 +1,70 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-NOT: llvm.memmove
+
+; CHECK-SPIRV: Variable {{[0-9]+}} [[mem:[0-9]+]] 7
+
+; CHECK-SPIRV: LifetimeStart [[mem]] [[size:[0-9]+]]
+; CHECK-SPIRV: Bitcast [[i8Ty:[0-9]+]] [[tmp1:[0-9]+]] [[mem]]
+; CHECK-SPIRV: CopyMemorySized [[tmp1]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: Bitcast [[i8Ty]] [[tmp2:[0-9]+]] [[mem]]
+; CHECK-SPIRV: CopyMemorySized {{[0-9]+}} [[tmp2]] {{[0-9]+}}
+; CHECK-SPIRV: LifetimeStop [[mem]] [[size]]
+
+; CHECK-LLVM-NOT: llvm.memmove
+
+; CHECK-LLVM: [[local:%[0-9]+]] = alloca %struct.SomeStruct
+; CHECK-LLVM: [[tmp1:%[0-9]+]] = bitcast %struct.SomeStruct* [[local]] to [[type:i[0-9]+\*]]
+; CHECK-LLVM: call void @llvm.lifetime.start({{i[0-9]+}} {{-?[0-9]+}}, [[type]] [[tmp1]])
+; CHECK-LLVM: [[tmp2:%[0-9]+]] = bitcast %struct.SomeStruct* [[local]] to [[type]]
+; CHECK-LLVM: call void @llvm.memcpy
+; CHECK-LLVM:  ([[type]] [[tmp2]],
+; CHECK-LLVM:  {{i[0-9]+}} [[size:[0-9]+]]
+; CHECK-LLVM: [[tmp3:%[0-9]+]] = bitcast %struct.SomeStruct* [[local]] to [[type]]
+; CHECK-LLVM: call void @llvm.memcpy
+; CHECK-LLVM:  , [[type]] [[tmp3]], {{i[0-9]+}} [[size]]
+; CHECK-LLVM: call void @llvm.lifetime.end({{i[0-9]+}} {{-?[0-9]+}}, [[type]] [[tmp1]])
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir-unknown-unknown"
+
+%struct.SomeStruct = type { <16 x float>, i32, [60 x i8] }
+
+; Function Attrs: nounwind
+define spir_kernel void @test_struct(%struct.SomeStruct addrspace(1)* nocapture readonly %in, %struct.SomeStruct addrspace(1)* nocapture %out) #0 {
+  %1 = bitcast %struct.SomeStruct addrspace(1)* %in to i8 addrspace(1)*
+  %2 = bitcast %struct.SomeStruct addrspace(1)* %out to i8 addrspace(1)*
+  call void @llvm.memmove.p1i8.p1i8.i32(i8 addrspace(1)* %2, i8 addrspace(1)* %1, i32 128, i32 64, i1 false)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @llvm.memmove.p1i8.p1i8.i32(i8 addrspace(1)* nocapture, i8 addrspace(1)* nocapture readonly, i32, i32, i1) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!7}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!9}
+
+!0 = !{void (%struct.SomeStruct addrspace(1)*, %struct.SomeStruct addrspace(1)*)* @test_struct, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"struct SomeStruct*", !"struct SomeStruct*"}
+!4 = !{!"kernel_arg_base_type", !"struct SomeStruct*", !"struct SomeStruct*"}
+!5 = !{!"kernel_arg_type_qual", !"const", !""}
+!6 = !{!"kernel_arg_name", !"in", !"out"}
+!7 = !{i32 1, i32 2}
+!8 = !{}
+!9 = !{!"clang version 3.6.1 (https://github.com/KhronosGroup/SPIR d7e44c3b27581e54ca0e522987d1ade2bd29b70d) (https://github.com/KhronosGroup/SPIRV-LLVM.git d42743684ea8338358504e44ef8363b9dc675c66)"}


### PR DESCRIPTION
Closes #205.

Produces following SPIR-V output for the example given in #205:

    119734787 65536 393230 22 0 
    2 Capability Addresses 
    2 Capability Kernel 
    2 Capability Vector16 
    2 Capability Int8 
    5 ExtInstImport 1 "OpenCL.std"
    3 MemoryModel 1 2 
    6 EntryPoint 6 12 "test_struct"
    3 Source 3 102000 
    7 Name 3 "struct.SomeStruct"
    3 Name 13 "in"
    3 Name 14 "out"
    4 Decorate 21 FuncParamAttr 5 
    2 DecorationGroup 21 
    4 Decorate 13 FuncParamAttr 6 
    4 GroupDecorate 21 13 14 
    4 TypeInt 6 32 0 
    4 TypeInt 8 8 0 
    4 Constant 6 7 60 
    4 Constant 6 20 128 
    2 TypeVoid 2 
    3 TypeFloat 4 32 
    4 TypeVector 5 4 16 
    4 TypeArray 9 8 7 
    5 TypeStruct 3 5 6 9 
    4 TypePointer 10 5 3 
    5 TypeFunction 11 2 10 10 
    4 TypePointer 16 5 8 
    
    5 Function 2 12 0 11 
    3 FunctionParameter 10 13 
    3 FunctionParameter 10 14 
    
    2 Label 15 
    4 Variable 2 19 7 
    4 Bitcast 16 17 13 
    4 Bitcast 16 18 14 
    3 LifetimeStart 19 128 
    6 CopyMemorySized 19 17 20 2 64 
    6 CopyMemorySized 18 19 20 2 64 
    3 LifetimeStop 19 128 
    1 Return 
    
    1 FunctionEnd 

This result is "correct" in the sense, that the code does the right thing, but:
- [x] The temporary Variable is of type `void` and has no size specified.
- [x] We probably should add `LifetimeStart` and `LifeTimeStop` before/after the `CopyMemorySized` instruction.
- [x] According to the [SPIR-V specification, section 2.4](https://www.khronos.org/registry/spir-v/specs/1.1/SPIRV.html#_a_id_logicallayout_a_logical_layout_of_a_module):
> All OpVariable instructions in a function must be in the first block in the function. These instructions, together with any immediately preceding OpLine instructions, must be the first instructions in that block. (Note the validation rules prevent OpPhi instructions in the first block of a function.) 