### PR TITLE
~SPIRVModuleImpl() crashes when delete no-id entries

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -130,7 +130,7 @@ SPIRVFunction::decode(std::istream &I) {
 /// Do it here instead of in BB:decode to avoid back track in input stream.
 void
 SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
-  SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock*>(Decoder.getEntry());
+  SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock*>(Decoder.getEntry(false));
   assert(BB);
   addBasicBlock(BB);
   SPIRVDBG(spvdbgs() << "Decode BB: " << BB->getId() << '\n');
@@ -147,7 +147,7 @@ SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
       continue;
     }
 
-    SPIRVInstruction *Inst = static_cast<SPIRVInstruction *>(Decoder.getEntry());
+    SPIRVInstruction *Inst = static_cast<SPIRVInstruction *>(Decoder.getEntry(false));
     assert(Inst);
     if (Inst->getOpCode() != OpUndef)
       BB->addInstruction(Inst);

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -110,6 +110,7 @@ SPIRVFunction::decode(std::istream &I) {
     case OpFunctionParameter: {
       auto Param = static_cast<SPIRVFunctionParameter *>(Decoder.getEntry());
       assert(Param);
+      Module->add(Param);
       Param->setParent(this);
       Parameters.push_back(Param);
       Decoder.getWordCountAndOpCode();
@@ -130,7 +131,7 @@ SPIRVFunction::decode(std::istream &I) {
 /// Do it here instead of in BB:decode to avoid back track in input stream.
 void
 SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
-  SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock*>(Decoder.getEntry(false));
+  SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock*>(Decoder.getEntry());
   assert(BB);
   addBasicBlock(BB);
   SPIRVDBG(spvdbgs() << "Decode BB: " << BB->getId() << '\n');
@@ -143,14 +144,16 @@ SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
     }
 
     if (Decoder.OpCode == OpLine) {
-      Decoder.getEntry();
+      Module->add(Decoder.getEntry());
       continue;
     }
 
-    SPIRVInstruction *Inst = static_cast<SPIRVInstruction *>(Decoder.getEntry(false));
+    SPIRVInstruction *Inst = static_cast<SPIRVInstruction *>(Decoder.getEntry());
     assert(Inst);
     if (Inst->getOpCode() != OpUndef)
       BB->addInstruction(Inst);
+    else
+      Module->add(Inst);
   }
   Decoder.setScope(this);
 }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -378,15 +378,12 @@ private:
 };
 
 SPIRVModuleImpl::~SPIRVModuleImpl() {
-  //ToDo: Fix bug causing crash
-  //for (auto I:IdEntryMap)
-  //  delete I.second;
+  for (auto I:IdEntryMap)
+    delete I.second;
 
-  // ToDo: Fix bug causing crash
-  //for (auto I:EntryNoId) {
-  //  bildbgs() << "[delete] " << *I;
-  //  delete I;
-  //}
+  for (auto I:EntryNoId) {
+    delete I;
+  }
 
   for (auto C : CapMap)
     delete C.second;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -332,7 +332,7 @@ private:
   SPIRVMemoryModelKind MemoryModel;
 
   typedef std::map<SPIRVId, SPIRVEntry *> SPIRVIdToEntryMap;
-  typedef std::vector<SPIRVEntry *> SPIRVEntryVector;
+  typedef std::set<SPIRVEntry *> SPIRVEntrySet;
   typedef std::set<SPIRVId> SPIRVIdSet;
   typedef std::vector<SPIRVId> SPIRVIdVec;
   typedef std::vector<SPIRVFunction *> SPIRVFunctionVector;
@@ -357,7 +357,7 @@ private:
   SPIRVFunctionVector FuncVec;
   SPIRVConstantVector ConstVec;
   SPIRVVariableVec VariableVec;
-  SPIRVEntryVector EntryNoId;         // Entries without id
+  SPIRVEntrySet EntryNoId;          // Entries without id
   SPIRVIdToBuiltinSetMap IdBuiltinMap;
   SPIRVIdSet NamedId;
   SPIRVStringVec StringVec;
@@ -382,12 +382,8 @@ SPIRVModuleImpl::~SPIRVModuleImpl() {
   //for (auto I:IdEntryMap)
   //  delete I.second;
 
-  for (auto I:EntryNoId) {
-    // Entry of OpLine will be deleted by
-    // std::shared_ptr automatically.
-    if (I->getOpCode() != OpLine)
-      delete I;
-  }
+  for (auto I : EntryNoId)
+    delete I;
 
   for (auto C : CapMap)
     delete C.second;
@@ -553,8 +549,9 @@ SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
     } else
       IdEntryMap[Id] = Entry;
   } else {
-    if (EntryNoId.empty() || EntryNoId.back() != Entry)
-      EntryNoId.push_back(Entry);
+    // Entry of OpLine will be deleted by std::shared_ptr automatically.
+    if (Entry->getOpCode() != OpLine)
+      EntryNoId.insert(Entry);
   }
 
   Entry->setModule(this);

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -231,7 +231,7 @@ SPIRVDecoder::getWordCountAndOpCode() {
 }
 
 SPIRVEntry *
-SPIRVDecoder::getEntry() {
+SPIRVDecoder::getEntry(bool Add) {
   if (WordCount == 0 || OpCode == OpNop)
     return NULL;
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
@@ -243,10 +243,11 @@ SPIRVDecoder::getEntry() {
   Entry->setWordCount(WordCount);
   Entry->setLine(M.getCurrentLine());
   IS >> *Entry;
-  if(Entry->isEndOfBlock() || OpCode == OpNoLine)
+  if (Entry->isEndOfBlock() || OpCode == OpNoLine)
     M.setCurrentLine(nullptr);
   assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
-  M.add(Entry);
+  if (Add)
+    M.add(Entry);
   return Entry;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -231,7 +231,7 @@ SPIRVDecoder::getWordCountAndOpCode() {
 }
 
 SPIRVEntry *
-SPIRVDecoder::getEntry(bool Add) {
+SPIRVDecoder::getEntry() {
   if (WordCount == 0 || OpCode == OpNop)
     return NULL;
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
@@ -241,13 +241,12 @@ SPIRVDecoder::getEntry(bool Add) {
   else
     Entry->setScope(Scope);
   Entry->setWordCount(WordCount);
-  Entry->setLine(M.getCurrentLine());
+  if (OpCode != OpLine)
+    Entry->setLine(M.getCurrentLine());
   IS >> *Entry;
   if (Entry->isEndOfBlock() || OpCode == OpNoLine)
     M.setCurrentLine(nullptr);
   assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
-  if (Add)
-    M.add(Entry);
   return Entry;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -74,7 +74,7 @@ public:
 
   void setScope(SPIRVEntry *);
   bool getWordCountAndOpCode();
-  SPIRVEntry *getEntry(bool Add = true);
+  SPIRVEntry *getEntry();
   void validate()const;
 
   std::istream &IS;

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -74,7 +74,7 @@ public:
 
   void setScope(SPIRVEntry *);
   bool getWordCountAndOpCode();
-  SPIRVEntry *getEntry();
+  SPIRVEntry *getEntry(bool Add = true);
   void validate()const;
 
   std::istream &IS;


### PR DESCRIPTION
It crashes because it tries to delete some no-id entry (OpStore) twice, which is
pushed into vector "EntryNoId" twice.

Do not add entries of SPIRVBasicBlock and SPIRVInstruction into Module when call
Decoder.getEntry(). They will be added at addBasicBlock() and addInstruction().