### PR TITLE
~SPIRVModuleImpl() crashes when delete id entries

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -247,7 +247,6 @@ private:
       assert (Loc->second->isForward() &&
           "LLVM Value is mapped to different SPIRV Values");
       auto Forward = static_cast<SPIRVForward *>(Loc->second);
-      BV->setId(Forward->getId());
       BM->replaceForward(Forward, BV);
     }
     ValueMap[V] = BV;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -378,12 +378,11 @@ private:
 };
 
 SPIRVModuleImpl::~SPIRVModuleImpl() {
-  //ToDo: Fix bug causing crash
-  //for (auto I:IdEntryMap)
-  //  delete I.second;
-
   for (auto I : EntryNoId)
     delete I;
+
+  for (auto I : IdEntryMap)
+    delete I.second;
 
   for (auto C : CapMap)
     delete C.second;


### PR DESCRIPTION
A forwarded entry has 2 duplicate elements in "IdEntryMap", one element is
at map slot of old id, and another is at forward id.