### PR TITLE
Decoder.getEntry() may returns NULL

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1506,7 +1506,7 @@ operator>> (std::istream &I, SPIRVModule &M) {
 
   while (Decoder.getWordCountAndOpCode()) {
     SPIRVEntry *Entry = Decoder.getEntry();
-    if (Entry != NULL)
+    if (Entry != nullptr)
       M.add(Entry);
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1504,8 +1504,11 @@ operator>> (std::istream &I, SPIRVModule &M) {
   Decoder >> MI.InstSchema;
   assert(MI.InstSchema == SPIRVISCH_Default && "Unsupported instruction schema");
 
-  while(Decoder.getWordCountAndOpCode())
-    M.add(Decoder.getEntry());
+  while (Decoder.getWordCountAndOpCode()) {
+    SPIRVEntry *Entry = Decoder.getEntry();
+    if (Entry != NULL)
+      M.add(Entry);
+  }
 
   MI.optimizeDecorates();
   MI.resolveUnknownStructFields();

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -233,7 +233,7 @@ SPIRVDecoder::getWordCountAndOpCode() {
 SPIRVEntry *
 SPIRVDecoder::getEntry() {
   if (WordCount == 0 || OpCode == OpNop)
-    return NULL;
+    return nullptr;
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
   assert(Entry);
   Entry->setModule(&M);

--- a/test/SPIRV/redundant_word.spt
+++ b/test/SPIRV/redundant_word.spt
@@ -33,3 +33,4 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
+

--- a/test/SPIRV/useless_word.spt
+++ b/test/SPIRV/useless_word.spt
@@ -1,0 +1,35 @@
+119734787 65536 393230 11 0 
+2 Capability Addresses 
+0 Capability 
+2 Capability Kernel 
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2 
+6 EntryPoint 6 5 "fmod_kernel"
+3 Source 3 200000 
+3 Name 6 "out"
+3 Name 7 "in1"
+3 Name 8 "in2"
+4 Name 9 "entry"
+4 Name 10 "call"
+2 TypeVoid 2 
+3 TypeFloat 3 32 
+6 TypeFunction 4 2 3 3 3 
+0 Nop 
+
+5 Function 2 5 0 4 
+3 FunctionParameter 3 6 
+3 FunctionParameter 3 7 
+3 FunctionParameter 3 8 
+
+2 Label 9 
+7 ExtInst 3 10 1 fmod 7 8 
+1 Return 
+
+1 FunctionEnd 
+
+
+; FIXME: LIT comments/commands are moved at the end because llvm-spirv stops
+; reading the file after first ';' symbol
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc


### PR DESCRIPTION
This happens when SPIR-V binary contains useless word which does not belong to
any instruction. Its high 16-bit is 0, and the decoder discards it.