### PR TITLE
Fix for intel_sub_group_block_read with short type.

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2224,11 +2224,13 @@ SPIRVToLLVM::getOCLBuiltinName(SPIRVInstruction* BI) {
     default:
       return OCLSPIRVBuiltinMap::rmap(OC);
     }
-    if (DataTy && DataTy->isTypeVector()) {
-      if (DataTy->getVectorComponentType()->getBitWidth() == 16)
+    if (DataTy) {
+      if (DataTy->getBitWidth() == 16)
         Name << "_us";
-      if (unsigned ComponentCount = DataTy->getVectorComponentCount())
-        Name << ComponentCount;
+      if (DataTy->isTypeVector()) {
+        if (unsigned ComponentCount = DataTy->getVectorComponentCount())
+          Name << ComponentCount;
+      }
     }
     return Name.str();
   }


### PR DESCRIPTION
With previous code, when intel_sub_group_block_read_us scalar function
was being used, we generated __builtin_spirv_intel_sub_group_block_read_p1i16
built-in name. For naming consistency with OpenCL functions, it should have the "us" included, i.e.
__builtin_spirv_intel_sub_group_block_read_us_p1i16