### PR TITLE
Fix compile error: Use explicit conversion of `unique_ptr` to `bool`

### DIFF
--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -101,7 +101,7 @@ public:
 
   ~ValueMap() {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return bool(MDMap); }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);


### PR DESCRIPTION
The aging LLVM code is converting  an object of type `unique_ptr` to
an object  of type  `bool`; this is  being done  implicitly, thereby
causing  a compile-time  error  with  a modern,  standards-compliant
compiler.

This is explained well here:

    https://github.com/microsoft/DirectXShaderCompiler/issues/1692

In particular:

> The C++  standard specifies operator  bool on unique_ptr  as being
> explicit,  so this  is  clearly a  bug in  the  LLVM source  code:
> https://en.cppreference.com/w/cpp/memory/unique_ptr/operator_bool

This commit merely makes the  conversion explicit, allowing the code
to be built by GCC version 9.1.0.

This  bug was  fixed  by the  LLVM  project proper  as  part of  the
following commit:

    69341e6abca92f7f118ee7bd99be0cdfc649386f
    2016-04-08
    https://github.com/llvm/llvm-project/commit/69341e6abca92f7f118ee7bd99be0cdfc649386f